### PR TITLE
feat: extend election model with quorum and voting endpoints

### DIFF
--- a/BvgAuthApi/BvgAuthApi.csproj
+++ b/BvgAuthApi/BvgAuthApi.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="2.2.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+    <PackageReference Include="EPPlus" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/BvgAuthApi/Data/BvgDbContext.cs
+++ b/BvgAuthApi/Data/BvgDbContext.cs
@@ -17,6 +17,9 @@ namespace BvgAuthApi.Data
         public DbSet<Election> Elections => Set<Election>();
         public DbSet<ElectionQuestion> Questions => Set<ElectionQuestion>();
         public DbSet<ElectionOption> Options => Set<ElectionOption>();
+        public DbSet<PadronEntry> Padron => Set<PadronEntry>();
+        public DbSet<ElectionUserAssignment> ElectionUserAssignments => Set<ElectionUserAssignment>();
+        public DbSet<VoteRecord> Votes => Set<VoteRecord>();
 
         protected override void OnModelCreating(ModelBuilder b)
         {
@@ -26,6 +29,9 @@ namespace BvgAuthApi.Data
                 e.Property(x => x.Name).IsRequired().HasMaxLength(200);
                 e.Property(x => x.Details).HasMaxLength(2000);
                 e.HasMany(x => x.Questions).WithOne().HasForeignKey(q => q.ElectionId).OnDelete(DeleteBehavior.Cascade);
+                e.HasMany(x => x.Padron).WithOne().HasForeignKey(p => p.ElectionId).OnDelete(DeleteBehavior.Cascade);
+                e.HasMany(x => x.Assignments).WithOne().HasForeignKey(a => a.ElectionId).OnDelete(DeleteBehavior.Cascade);
+                e.HasMany(x => x.Votes).WithOne().HasForeignKey(v => v.ElectionId).OnDelete(DeleteBehavior.Cascade);
             });
             b.Entity<ElectionQuestion>(q =>
             {
@@ -35,6 +41,19 @@ namespace BvgAuthApi.Data
             b.Entity<ElectionOption>(o =>
             {
                 o.Property(x => x.Text).IsRequired().HasMaxLength(500);
+            });
+            b.Entity<PadronEntry>(p =>
+            {
+                p.Property(x => x.ShareholderId).HasMaxLength(100);
+                p.Property(x => x.ShareholderName).HasMaxLength(200);
+            });
+            b.Entity<ElectionUserAssignment>(a =>
+            {
+                a.HasIndex(x => new { x.ElectionId, x.UserId, x.Role }).IsUnique();
+            });
+            b.Entity<VoteRecord>(v =>
+            {
+                v.HasKey(x => x.Id);
             });
         }
     }

--- a/BvgAuthApi/Endpoints/ElectionEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ElectionEndpoints.cs
@@ -1,8 +1,12 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
+using OfficeOpenXml;
 using BvgAuthApi.Data;
+using BvgAuthApi.Hubs;
 using BvgAuthApi.Models;
+using System.Security.Claims;
 
 namespace BvgAuthApi.Endpoints
 {
@@ -10,7 +14,7 @@ namespace BvgAuthApi.Endpoints
     {
         public static IEndpointRouteBuilder MapElections(this IEndpointRouteBuilder app)
         {
-            var g = app.MapGroup("/api/elections").RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+            var g = app.MapGroup("/api/elections");
 
             g.MapPost("/", async ([FromBody] CreateElectionDto dto, BvgDbContext db) =>
             {
@@ -18,7 +22,8 @@ namespace BvgAuthApi.Endpoints
                 {
                     Name = dto.Name,
                     Details = dto.Details ?? "",
-                    ScheduledAt = dto.ScheduledAt
+                    ScheduledAt = dto.ScheduledAt,
+                    QuorumMinimo = dto.QuorumMinimo
                 };
                 foreach (var q in dto.Questions)
                 {
@@ -30,19 +35,120 @@ namespace BvgAuthApi.Endpoints
                 db.Elections.Add(e);
                 await db.SaveChangesAsync();
                 return Results.Created($"/api/elections/{e.Id}", new { e.Id });
-            });
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
 
             g.MapGet("/", async (BvgDbContext db) =>
                 Results.Ok(await db.Elections.AsNoTracking()
                     .Select(e => new {
-                        e.Id, e.Name, e.Details, e.ScheduledAt,
+                        e.Id, e.Name, e.Details, e.ScheduledAt, e.QuorumMinimo,
                         Questions = e.Questions.Select(q => new { q.Id, q.Text, Options = q.Options.Select(o => new { o.Id, o.Text }) })
-                    }).ToListAsync()));
+                    }).ToListAsync()))
+                .RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+
+            g.MapPost("/{id}/padron", async (Guid id, IFormFile file, BvgDbContext db) =>
+            {
+                var election = await db.Elections.Include(x => x.Padron).FirstOrDefaultAsync(x => x.Id == id);
+                if (election is null) return Results.NotFound();
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+                using var ms = new MemoryStream();
+                await file.CopyToAsync(ms);
+                using var pkg = new ExcelPackage(ms);
+                var ws = pkg.Workbook.Worksheets.First();
+                for (int row = 2; ws.Cells[row,1].Value != null; row++)
+                {
+                    var entry = new PadronEntry
+                    {
+                        ElectionId = id,
+                        ShareholderId = ws.Cells[row,1].Text,
+                        ShareholderName = ws.Cells[row,2].Text,
+                        LegalRepresentative = ws.Cells[row,3].Text,
+                        Proxy = ws.Cells[row,4].Text,
+                        Shares = decimal.TryParse(ws.Cells[row,5].Text, out var s) ? s : 0
+                    };
+                    election.Padron.Add(entry);
+                }
+                await db.SaveChangesAsync();
+                return Results.Ok();
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+
+            g.MapGet("/{id}/padron/template", () =>
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+                using var pkg = new ExcelPackage();
+                var ws = pkg.Workbook.Worksheets.Add("Padron");
+                ws.Cells[1,1].Value = "Id";
+                ws.Cells[1,2].Value = "NombreAccionista";
+                ws.Cells[1,3].Value = "RepresentanteLegal";
+                ws.Cells[1,4].Value = "Apoderado";
+                ws.Cells[1,5].Value = "Acciones";
+                var bytes = pkg.GetAsByteArray();
+                return Results.File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "padron.xlsx");
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+
+            g.MapPost("/{id}/attendance/{padronId}", async (Guid id, Guid padronId, [FromBody] AttendanceDto dto, BvgDbContext db, IHubContext<LiveHub> hub) =>
+            {
+                var election = await db.Elections.Include(e => e.Padron).FirstOrDefaultAsync(e => e.Id == id);
+                if (election is null) return Results.NotFound();
+                var padron = election.Padron.FirstOrDefault(p => p.Id == padronId);
+                if (padron is null) return Results.NotFound();
+                padron.Attendance = dto.Attendance;
+                await db.SaveChangesAsync();
+                var total = election.Padron.Sum(p => p.Shares);
+                var present = election.Padron.Where(p => p.Attendance != AttendanceType.None).Sum(p => p.Shares);
+                await hub.Clients.All.SendAsync("quorumUpdated", new { ElectionId = id, Total = total, Present = present });
+                return Results.Ok();
+            }).RequireAuthorization(AppRoles.ElectionRegistrar);
+
+            g.MapGet("/{id}/quorum", async (Guid id, BvgDbContext db) =>
+            {
+                var election = await db.Elections.Include(e => e.Padron).FirstOrDefaultAsync(e => e.Id == id);
+                if (election is null) return Results.NotFound();
+                var total = election.Padron.Sum(p => p.Shares);
+                var present = election.Padron.Where(p => p.Attendance != AttendanceType.None).Sum(p => p.Shares);
+                return Results.Ok(new { Total = total, Present = present, Quorum = total == 0 ? 0 : present / total });
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin},{AppRoles.ElectionObserver},{AppRoles.ElectionRegistrar}");
+
+            g.MapPost("/{id}/votes", async (Guid id, [FromBody] VoteDto dto, BvgDbContext db, IHubContext<LiveHub> hub, ClaimsPrincipal user) =>
+            {
+                var election = await db.Elections.Include(e => e.Padron).Include(e => e.Votes).FirstOrDefaultAsync(e => e.Id == id);
+                if (election is null) return Results.NotFound();
+                var registrarId = user.FindFirst("sub")?.Value ?? "";
+                var vote = new VoteRecord
+                {
+                    ElectionId = id,
+                    PadronEntryId = dto.PadronId,
+                    ElectionQuestionId = dto.QuestionId,
+                    ElectionOptionId = dto.OptionId,
+                    RegistrarId = registrarId
+                };
+                db.Votes.Add(vote);
+                await db.SaveChangesAsync();
+                await hub.Clients.All.SendAsync("voteRegistered", new { ElectionId = id, QuestionId = dto.QuestionId, OptionId = dto.OptionId });
+                return Results.Ok();
+            }).RequireAuthorization(AppRoles.ElectionRegistrar);
+
+            g.MapGet("/{id}/results", async (Guid id, BvgDbContext db) =>
+            {
+                var election = await db.Elections.Include(e => e.Questions).ThenInclude(q => q.Options).Include(e => e.Votes).FirstOrDefaultAsync(e => e.Id == id);
+                if (election is null) return Results.NotFound();
+                var results = election.Questions.Select(q => new {
+                    QuestionId = q.Id,
+                    q.Text,
+                    Options = q.Options.Select(o => new {
+                        OptionId = o.Id,
+                        o.Text,
+                        Votes = election.Votes.Count(v => v.ElectionQuestionId == q.Id && v.ElectionOptionId == o.Id)
+                    })
+                });
+                return Results.Ok(results);
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin},{AppRoles.ElectionObserver}");
 
             return app;
         }
 
-        public record CreateElectionDto(string Name, string? Details, DateTimeOffset ScheduledAt, List<CreateQuestionDto> Questions);
+        public record CreateElectionDto(string Name, string? Details, DateTimeOffset ScheduledAt, decimal QuorumMinimo, List<CreateQuestionDto> Questions);
         public record CreateQuestionDto(string Text, List<string> Options);
+        public record AttendanceDto(AttendanceType Attendance);
+        public record VoteDto(Guid PadronId, Guid QuestionId, Guid OptionId);
     }
 }

--- a/BvgAuthApi/Models/AppModels.cs
+++ b/BvgAuthApi/Models/AppModels.cs
@@ -5,6 +5,9 @@
         public const string GlobalAdmin = "GlobalAdmin";
         public const string VoteAdmin   = "VoteAdmin";
         public const string VoteOperator= "VoteOperator";
+        public const string ElectionRegistrar = "ElectionRegistrar";
+        public const string ElectionObserver  = "ElectionObserver";
+        public const string ElectionVoter     = "ElectionVoter";
     }
 
     public class Election
@@ -13,7 +16,11 @@
         public string Name { get; set; } = default!;
         public string Details { get; set; } = "";
         public DateTimeOffset ScheduledAt { get; set; }
+        public decimal QuorumMinimo { get; set; }
+        public List<PadronEntry> Padron { get; set; } = new();
+        public List<ElectionUserAssignment> Assignments { get; set; } = new();
         public List<ElectionQuestion> Questions { get; set; } = new();
+        public List<VoteRecord> Votes { get; set; } = new();
         public bool IsClosed { get; set; }
     }
 
@@ -30,5 +37,43 @@
         public Guid Id { get; set; } = Guid.NewGuid();
         public Guid ElectionQuestionId { get; set; }
         public string Text { get; set; } = default!;
+    }
+
+    public enum AttendanceType
+    {
+        None,
+        Virtual,
+        Presencial
+    }
+
+    public class PadronEntry
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public Guid ElectionId { get; set; }
+        public string ShareholderId { get; set; } = default!;
+        public string ShareholderName { get; set; } = default!;
+        public string? LegalRepresentative { get; set; }
+        public string? Proxy { get; set; }
+        public decimal Shares { get; set; }
+        public AttendanceType Attendance { get; set; } = AttendanceType.None;
+    }
+
+    public class ElectionUserAssignment
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public Guid ElectionId { get; set; }
+        public string UserId { get; set; } = default!;
+        public string Role { get; set; } = default!;
+    }
+
+    public class VoteRecord
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public Guid ElectionId { get; set; }
+        public Guid PadronEntryId { get; set; }
+        public Guid ElectionQuestionId { get; set; }
+        public Guid ElectionOptionId { get; set; }
+        public string RegistrarId { get; set; } = default!;
+        public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
     }
 }

--- a/BvgAuthApi/Program.cs
+++ b/BvgAuthApi/Program.cs
@@ -55,6 +55,9 @@ builder.Services.AddAuthorization(opt =>
     opt.AddPolicy(AppRoles.GlobalAdmin, p => p.RequireRole(AppRoles.GlobalAdmin));
     opt.AddPolicy(AppRoles.VoteAdmin,   p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin));
     opt.AddPolicy(AppRoles.VoteOperator,p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.VoteOperator));
+    opt.AddPolicy(AppRoles.ElectionRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionRegistrar));
+    opt.AddPolicy(AppRoles.ElectionObserver,  p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionObserver));
+    opt.AddPolicy(AppRoles.ElectionVoter,     p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionVoter));
 });
 
 builder.Services.AddSignalR();

--- a/BvgAuthApi/Seed/DataSeeder.cs
+++ b/BvgAuthApi/Seed/DataSeeder.cs
@@ -15,7 +15,7 @@ namespace BvgAuthApi.Seed
             var um  = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
             // Roles
-            foreach (var r in new[] { AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.VoteOperator })
+            foreach (var r in new[] { AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.VoteOperator, AppRoles.ElectionRegistrar, AppRoles.ElectionObserver, AppRoles.ElectionVoter })
                 if (!await rm.RoleExistsAsync(r)) await rm.CreateAsync(new IdentityRole(r));
 
             // Admin


### PR DESCRIPTION
## Summary
- add election-specific roles and seed them
- extend election model with padrón, quorum and vote records
- implement endpoints for padrón upload, attendance, voting and results with SignalR updates
- include EPPlus package for Excel processing

## Testing
- `dotnet restore` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures missing)*

------
https://chatgpt.com/codex/tasks/task_b_68ae2042832c832289426c79e7cf0cdc