### PR TITLE
Add election user assignments and quorum validations

### DIFF
--- a/BvgAuthApi/Endpoints/ElectionEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ElectionEndpoints.cs
@@ -71,6 +71,38 @@ namespace BvgAuthApi.Endpoints
                 return Results.Ok();
             }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
 
+            g.MapPost("/{id}/assignments", async (Guid id, [FromBody] AssignmentDto dto, BvgDbContext db) =>
+            {
+                var election = await db.Elections.FindAsync(id);
+                if (election is null) return Results.NotFound();
+                db.ElectionUserAssignments.Add(new ElectionUserAssignment
+                {
+                    ElectionId = id,
+                    UserId = dto.UserId,
+                    Role = dto.Role
+                });
+                await db.SaveChangesAsync();
+                return Results.Ok();
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+
+            g.MapGet("/{id}/assignments", async (Guid id, BvgDbContext db) =>
+            {
+                var items = await db.ElectionUserAssignments
+                    .Where(a => a.ElectionId == id)
+                    .Select(a => new { a.Id, a.UserId, a.Role })
+                    .ToListAsync();
+                return Results.Ok(items);
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+
+            g.MapDelete("/{id}/assignments/{assignmentId}", async (Guid id, Guid assignmentId, BvgDbContext db) =>
+            {
+                var assignment = await db.ElectionUserAssignments.FirstOrDefaultAsync(a => a.Id == assignmentId && a.ElectionId == id);
+                if (assignment is null) return Results.NotFound();
+                db.ElectionUserAssignments.Remove(assignment);
+                await db.SaveChangesAsync();
+                return Results.NoContent();
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+
             g.MapGet("/{id}/padron/template", () =>
             {
                 ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
@@ -85,10 +117,15 @@ namespace BvgAuthApi.Endpoints
                 return Results.File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "padron.xlsx");
             }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
 
-            g.MapPost("/{id}/attendance/{padronId}", async (Guid id, Guid padronId, [FromBody] AttendanceDto dto, BvgDbContext db, IHubContext<LiveHub> hub) =>
+            g.MapPost("/{id}/attendance/{padronId}", async (Guid id, Guid padronId, [FromBody] AttendanceDto dto, BvgDbContext db, IHubContext<LiveHub> hub, ClaimsPrincipal user) =>
             {
+                var userId = user.FindFirst("sub")?.Value ?? "";
+                var isAdmin = user.IsInRole(AppRoles.GlobalAdmin) || user.IsInRole(AppRoles.VoteAdmin);
+                if (!isAdmin && !await db.ElectionUserAssignments.AnyAsync(a => a.ElectionId == id && a.UserId == userId && a.Role == AppRoles.ElectionRegistrar))
+                    return Results.Forbid();
                 var election = await db.Elections.Include(e => e.Padron).FirstOrDefaultAsync(e => e.Id == id);
                 if (election is null) return Results.NotFound();
+                if (election.IsClosed) return Results.BadRequest();
                 var padron = election.Padron.FirstOrDefault(p => p.Id == padronId);
                 if (padron is null) return Results.NotFound();
                 padron.Attendance = dto.Attendance;
@@ -99,10 +136,17 @@ namespace BvgAuthApi.Endpoints
                 return Results.Ok();
             }).RequireAuthorization(AppRoles.ElectionRegistrar);
 
-            g.MapGet("/{id}/quorum", async (Guid id, BvgDbContext db) =>
+            g.MapGet("/{id}/quorum", async (Guid id, BvgDbContext db, ClaimsPrincipal user) =>
             {
                 var election = await db.Elections.Include(e => e.Padron).FirstOrDefaultAsync(e => e.Id == id);
                 if (election is null) return Results.NotFound();
+                var userId = user.FindFirst("sub")?.Value ?? "";
+                var isAdmin = user.IsInRole(AppRoles.GlobalAdmin) || user.IsInRole(AppRoles.VoteAdmin);
+                if (!isAdmin)
+                {
+                    var hasAssign = await db.ElectionUserAssignments.AnyAsync(a => a.ElectionId == id && a.UserId == userId && (a.Role == AppRoles.ElectionObserver || a.Role == AppRoles.ElectionRegistrar));
+                    if (!hasAssign) return Results.Forbid();
+                }
                 var total = election.Padron.Sum(p => p.Shares);
                 var present = election.Padron.Where(p => p.Attendance != AttendanceType.None).Sum(p => p.Shares);
                 return Results.Ok(new { Total = total, Present = present, Quorum = total == 0 ? 0 : present / total });
@@ -110,9 +154,18 @@ namespace BvgAuthApi.Endpoints
 
             g.MapPost("/{id}/votes", async (Guid id, [FromBody] VoteDto dto, BvgDbContext db, IHubContext<LiveHub> hub, ClaimsPrincipal user) =>
             {
+                var userId = user.FindFirst("sub")?.Value ?? "";
+                var isAdmin = user.IsInRole(AppRoles.GlobalAdmin) || user.IsInRole(AppRoles.VoteAdmin);
+                if (!isAdmin && !await db.ElectionUserAssignments.AnyAsync(a => a.ElectionId == id && a.UserId == userId && a.Role == AppRoles.ElectionRegistrar))
+                    return Results.Forbid();
                 var election = await db.Elections.Include(e => e.Padron).Include(e => e.Votes).FirstOrDefaultAsync(e => e.Id == id);
                 if (election is null) return Results.NotFound();
-                var registrarId = user.FindFirst("sub")?.Value ?? "";
+                if (election.IsClosed) return Results.BadRequest();
+                var total = election.Padron.Sum(p => p.Shares);
+                var present = election.Padron.Where(p => p.Attendance != AttendanceType.None).Sum(p => p.Shares);
+                if (total == 0 || present / total < election.QuorumMinimo)
+                    return Results.BadRequest();
+                var registrarId = userId;
                 var vote = new VoteRecord
                 {
                     ElectionId = id,
@@ -127,10 +180,17 @@ namespace BvgAuthApi.Endpoints
                 return Results.Ok();
             }).RequireAuthorization(AppRoles.ElectionRegistrar);
 
-            g.MapGet("/{id}/results", async (Guid id, BvgDbContext db) =>
+            g.MapGet("/{id}/results", async (Guid id, BvgDbContext db, ClaimsPrincipal user) =>
             {
                 var election = await db.Elections.Include(e => e.Questions).ThenInclude(q => q.Options).Include(e => e.Votes).FirstOrDefaultAsync(e => e.Id == id);
                 if (election is null) return Results.NotFound();
+                var userId = user.FindFirst("sub")?.Value ?? "";
+                var isAdmin = user.IsInRole(AppRoles.GlobalAdmin) || user.IsInRole(AppRoles.VoteAdmin);
+                if (!isAdmin)
+                {
+                    var hasAssign = await db.ElectionUserAssignments.AnyAsync(a => a.ElectionId == id && a.UserId == userId && a.Role == AppRoles.ElectionObserver);
+                    if (!hasAssign) return Results.Forbid();
+                }
                 var results = election.Questions.Select(q => new {
                     QuestionId = q.Id,
                     q.Text,
@@ -143,6 +203,15 @@ namespace BvgAuthApi.Endpoints
                 return Results.Ok(results);
             }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin},{AppRoles.ElectionObserver}");
 
+            g.MapPost("/{id}/close", async (Guid id, BvgDbContext db) =>
+            {
+                var election = await db.Elections.FirstOrDefaultAsync(e => e.Id == id);
+                if (election is null) return Results.NotFound();
+                election.IsClosed = true;
+                await db.SaveChangesAsync();
+                return Results.Ok();
+            }).RequireAuthorization($"{AppRoles.GlobalAdmin},{AppRoles.VoteAdmin}");
+
             return app;
         }
 
@@ -150,5 +219,6 @@ namespace BvgAuthApi.Endpoints
         public record CreateQuestionDto(string Text, List<string> Options);
         public record AttendanceDto(AttendanceType Attendance);
         public record VoteDto(Guid PadronId, Guid QuestionId, Guid OptionId);
+        public record AssignmentDto(string UserId, string Role);
     }
 }


### PR DESCRIPTION
## Summary
- add endpoints to assign users to elections
- validate user assignments and quorum before attendance and voting
- allow admins to close elections

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68ae22561c608322813d994064f25c43