### PR TITLE
feat: add Angular frontend skeleton

### DIFF
--- a/CLIENT_README.md
+++ b/CLIENT_README.md
@@ -1,0 +1,42 @@
+# VotNET Frontend
+
+## Requisitos
+
+- Node.js 20+
+- Angular CLI 17
+
+## Instalación
+
+```bash
+cd votnet-client
+npm install
+```
+
+## Desarrollo
+
+```bash
+npm start
+```
+
+La aplicación se servirá en `http://localhost:4200` y consumirá el backend a través de `API_BASE_URL` definido en `src/environments`.
+
+## Estructura del proyecto
+
+- `src/app/login`: componentes de autenticación.
+- `src/app/user-admin`: módulo para administración de usuarios.
+- `src/app/elections`: módulo para gestión de elecciones y resultados.
+- `src/app/services`: servicios compartidos.
+
+## Estilos
+
+Se utilizan temas de Angular Material con estilos globales en `src/styles.css`.
+
+## Despliegue
+
+Construir la aplicación con:
+
+```bash
+npm run build
+```
+
+El contenido generado en `dist/` puede desplegarse como archivos estáticos. Asegúrate de configurar CORS y la variable `API_BASE_URL` en el backend según el entorno.

--- a/votnet-client/angular.json
+++ b/votnet-client/angular.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json.schemastore.org/angular-cli",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "votnet-client": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/votnet-client",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [{
+                "type": "initial",
+                "maximumWarning": "500kb",
+                "maximumError": "1mb"
+              }],
+              "outputHashing": "all"
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "votnet-client:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "scripts": [],
+            "styles": ["src/styles.css"],
+            "assets": ["src/favicon.ico", "src/assets"]
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "votnet-client"
+}

--- a/votnet-client/karma.conf.js
+++ b/votnet-client/karma.conf.js
@@ -1,0 +1,29 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadless'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/votnet-client/package.json
+++ b/votnet-client/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "votnet-client",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint",
+    "e2e": "ng e2e"
+  },
+  "dependencies": {
+    "@angular/animations": "17.3.0",
+    "@angular/common": "17.3.0",
+    "@angular/compiler": "17.3.0",
+    "@angular/core": "17.3.0",
+    "@angular/forms": "17.3.0",
+    "@angular/platform-browser": "17.3.0",
+    "@angular/platform-browser-dynamic": "17.3.0",
+    "@angular/router": "17.3.0",
+    "@angular/material": "17.3.0",
+    "@angular/cdk": "17.3.0",
+    "@microsoft/signalr": "8.0.0",
+    "rxjs": "7.8.1",
+    "tslib": "2.6.2",
+    "zone.js": "0.14.3"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "17.3.3",
+    "@angular/cli": "17.3.3",
+    "@angular/compiler-cli": "17.3.0",
+    "@types/jasmine": "5.1.0",
+    "jasmine-core": "5.1.0",
+    "karma": "6.4.2",
+    "karma-chrome-launcher": "3.2.0",
+    "karma-coverage": "2.2.0",
+    "karma-jasmine": "5.1.0",
+    "karma-jasmine-html-reporter": "2.1.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/votnet-client/src/app/app-routing.module.ts
+++ b/votnet-client/src/app/app-routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { LoginComponent } from './login/login.component';
+
+const routes: Routes = [
+  { path: 'login', component: LoginComponent },
+  {
+    path: 'users',
+    loadChildren: () => import('./user-admin/user-admin.module').then(m => m.UserAdminModule)
+  },
+  {
+    path: 'elections',
+    loadChildren: () => import('./elections/elections.module').then(m => m.ElectionsModule)
+  },
+  { path: '', redirectTo: 'elections', pathMatch: 'full' }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule {}

--- a/votnet-client/src/app/app.component.html
+++ b/votnet-client/src/app/app.component.html
@@ -1,0 +1,1 @@
+<app-layout></app-layout>

--- a/votnet-client/src/app/app.component.ts
+++ b/votnet-client/src/app/app.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent {}

--- a/votnet-client/src/app/app.module.ts
+++ b/votnet-client/src/app/app.module.ts
@@ -1,0 +1,41 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { LayoutComponent } from './layout/layout.component';
+import { LoginComponent } from './login/login.component';
+import { authInterceptor } from './services/auth.interceptor';
+
+@NgModule({
+  declarations: [AppComponent, LayoutComponent, LoginComponent],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    HttpClientModule,
+    ReactiveFormsModule,
+    AppRoutingModule,
+    MatSidenavModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatListModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule
+  ],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useValue: authInterceptor, multi: true }
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/votnet-client/src/app/elections/election-create.component.css
+++ b/votnet-client/src/app/elections/election-create.component.css
@@ -1,0 +1,2 @@
+form { display: flex; flex-direction: column; }
+mat-form-field { width: 300px; }

--- a/votnet-client/src/app/elections/election-create.component.html
+++ b/votnet-client/src/app/elections/election-create.component.html
@@ -1,0 +1,27 @@
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <mat-form-field appearance="fill">
+    <mat-label>Name</mat-label>
+    <input matInput formControlName="name">
+  </mat-form-field>
+  <div formArrayName="questions">
+    <div *ngFor="let q of questions.controls; let i = index" [formGroupName]="i">
+      <h3>Question {{i + 1}}</h3>
+      <mat-form-field appearance="fill">
+        <mat-label>Text</mat-label>
+        <input matInput formControlName="text">
+      </mat-form-field>
+      <div formArrayName="options">
+        <div *ngFor="let o of options(i).controls; let j = index">
+          <mat-form-field appearance="fill">
+            <mat-label>Option {{j + 1}}</mat-label>
+            <input matInput [formControlName]="j">
+          </mat-form-field>
+        </div>
+      </div>
+      <button mat-button type="button" (click)="addOption(i)">Add Option</button>
+    </div>
+  </div>
+  <button mat-button type="button" (click)="addQuestion()">Add Question</button>
+  <input type="file" (change)="onFileChange($event)">
+  <button mat-raised-button color="primary" type="submit">Save</button>
+</form>

--- a/votnet-client/src/app/elections/election-list.component.css
+++ b/votnet-client/src/app/elections/election-list.component.css
@@ -1,0 +1,1 @@
+table { width: 100%; margin-top: 16px; }

--- a/votnet-client/src/app/elections/election-list.component.html
+++ b/votnet-client/src/app/elections/election-list.component.html
@@ -1,0 +1,15 @@
+<button mat-raised-button color="primary" (click)="create()">New Election</button>
+<table mat-table [dataSource]="elections" class="mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef> Name </th>
+    <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef> Actions </th>
+    <td mat-cell *matCellDef="let element">
+      <button mat-button (click)="results(element.id)">Results</button>
+    </td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/votnet-client/src/app/elections/election-list.component.ts
+++ b/votnet-client/src/app/elections/election-list.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-election-list',
+  templateUrl: './election-list.component.html'
+})
+export class ElectionListComponent {
+  displayedColumns = ['name', 'actions'];
+  elections: any[] = [];
+
+  constructor(private http: HttpClient, private router: Router) {
+    this.load();
+  }
+
+  load(): void {
+    this.http.get<any[]>(`${environment.apiBaseUrl}/elections`).subscribe(data => this.elections = data);
+  }
+
+  create(): void {
+    this.router.navigate(['/elections/create']);
+  }
+
+  results(id: string): void {
+    this.router.navigate(['/elections', id, 'results']);
+  }
+}

--- a/votnet-client/src/app/elections/elections.module.ts
+++ b/votnet-client/src/app/elections/elections.module.ts
@@ -1,0 +1,35 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatStepperModule } from '@angular/material/stepper';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ElectionListComponent } from './election-list.component';
+import { ElectionCreateComponent } from './election-create.component';
+import { ResultsComponent } from './results/results.component';
+
+const routes: Routes = [
+  { path: '', component: ElectionListComponent },
+  { path: 'create', component: ElectionCreateComponent },
+  { path: ':id/results', component: ResultsComponent }
+];
+
+@NgModule({
+  declarations: [ElectionListComponent, ElectionCreateComponent, ResultsComponent],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    MatTableModule,
+    MatButtonModule,
+    MatStepperModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressBarModule,
+    ReactiveFormsModule
+  ]
+})
+export class ElectionsModule {}

--- a/votnet-client/src/app/elections/results/results.component.css
+++ b/votnet-client/src/app/elections/results/results.component.css
@@ -1,0 +1,1 @@
+mat-progress-bar { margin-bottom: 8px; }

--- a/votnet-client/src/app/elections/results/results.component.html
+++ b/votnet-client/src/app/elections/results/results.component.html
@@ -1,0 +1,10 @@
+<div *ngIf="results as r">
+  <h2>{{r.name}}</h2>
+  <div *ngFor="let q of r.questions">
+    <h3>{{q.text}}</h3>
+    <div *ngFor="let o of q.options">
+      <div>{{o.text}} - {{o.votes}}</div>
+      <mat-progress-bar [value]="o.votes"></mat-progress-bar>
+    </div>
+  </div>
+</div>

--- a/votnet-client/src/app/elections/results/results.component.ts
+++ b/votnet-client/src/app/elections/results/results.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+import { LiveService } from '../../services/live.service';
+
+@Component({
+  selector: 'app-results',
+  templateUrl: './results.component.html'
+})
+export class ResultsComponent implements OnInit {
+  results: any;
+
+  constructor(private route: ActivatedRoute, private http: HttpClient, live: LiveService) {
+    live.quorumUpdated.subscribe(() => this.load());
+    live.voteRegistered.subscribe(() => this.load());
+  }
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    this.http.get(`${environment.apiBaseUrl}/elections/${id}/results`).subscribe(res => this.results = res);
+  }
+}

--- a/votnet-client/src/app/layout/layout.component.css
+++ b/votnet-client/src/app/layout/layout.component.css
@@ -1,0 +1,3 @@
+.sidenav-container { height: 100%; }
+.menu-button { margin-right: 8px; }
+.content { padding: 16px; }

--- a/votnet-client/src/app/layout/layout.component.html
+++ b/votnet-client/src/app/layout/layout.component.html
@@ -1,0 +1,21 @@
+<mat-sidenav-container class="sidenav-container">
+  <mat-sidenav #drawer mode="side" opened>
+    <mat-nav-list>
+      <a mat-list-item routerLink="/elections">Elections</a>
+      <a mat-list-item routerLink="/users">Users</a>
+      <a mat-list-item routerLink="/login">Login</a>
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content>
+    <mat-toolbar color="primary">
+      <button type="button" mat-icon-button (click)="drawer.toggle()" class="menu-button">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span>VotNET</span>
+    </mat-toolbar>
+    <div class="content">
+      <router-outlet></router-outlet>
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/votnet-client/src/app/layout/layout.component.ts
+++ b/votnet-client/src/app/layout/layout.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-layout',
+  templateUrl: './layout.component.html',
+  styleUrls: ['./layout.component.css']
+})
+export class LayoutComponent {}

--- a/votnet-client/src/app/login/login.component.css
+++ b/votnet-client/src/app/login/login.component.css
@@ -1,0 +1,6 @@
+.login-form {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+  margin: 32px auto;
+}

--- a/votnet-client/src/app/login/login.component.html
+++ b/votnet-client/src/app/login/login.component.html
@@ -1,0 +1,11 @@
+<form [formGroup]="form" (ngSubmit)="submit()" class="login-form">
+  <mat-form-field appearance="fill">
+    <mat-label>Username</mat-label>
+    <input matInput formControlName="username">
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Password</mat-label>
+    <input matInput type="password" formControlName="password">
+  </mat-form-field>
+  <button mat-raised-button color="primary" type="submit">Login</button>
+</form>

--- a/votnet-client/src/app/login/login.component.ts
+++ b/votnet-client/src/app/login/login.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { AuthService } from '../services/auth.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css']
+})
+export class LoginComponent {
+  form = this.fb.group({
+    username: ['', Validators.required],
+    password: ['', Validators.required]
+  });
+
+  constructor(private fb: FormBuilder, private auth: AuthService, private router: Router) {}
+
+  submit(): void {
+    if (this.form.invalid) return;
+    this.auth.login(this.form.value as any).subscribe(() => {
+      this.router.navigate(['/']);
+    });
+  }
+}

--- a/votnet-client/src/app/services/auth.interceptor.ts
+++ b/votnet-client/src/app/services/auth.interceptor.ts
@@ -1,0 +1,11 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from './auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = inject(AuthService).token;
+  if (token) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
+  return next(req);
+};

--- a/votnet-client/src/app/services/auth.service.ts
+++ b/votnet-client/src/app/services/auth.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+type LoginRequest = { username: string; password: string };
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly tokenKey = 'token';
+
+  constructor(private http: HttpClient) {}
+
+  login(data: LoginRequest): Observable<any> {
+    return this.http.post(`${environment.apiBaseUrl}/auth/login`, data, {
+      responseType: 'text'
+    }).pipe(tap(token => localStorage.setItem(this.tokenKey, token)));
+  }
+
+  get token(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenKey);
+  }
+}

--- a/votnet-client/src/app/services/live.service.ts
+++ b/votnet-client/src/app/services/live.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import * as signalR from '@microsoft/signalr';
+import { environment } from '../../environments/environment';
+import { Subject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class LiveService {
+  private hub = new signalR.HubConnectionBuilder()
+    .withUrl(environment.apiBaseUrl.replace('/api', '') + '/hubs/live')
+    .withAutomaticReconnect()
+    .build();
+
+  quorumUpdated = new Subject<any>();
+  voteRegistered = new Subject<any>();
+
+  constructor() {
+    this.hub.on('quorumUpdated', data => this.quorumUpdated.next(data));
+    this.hub.on('voteRegistered', data => this.voteRegistered.next(data));
+    this.hub.start().catch(err => console.error(err));
+  }
+}

--- a/votnet-client/src/app/user-admin/user-admin.module.ts
+++ b/votnet-client/src/app/user-admin/user-admin.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { ReactiveFormsModule } from '@angular/forms';
+import { UserListComponent, UserDialogComponent } from './user-list.component';
+
+const routes: Routes = [{ path: '', component: UserListComponent }];
+
+@NgModule({
+  declarations: [UserListComponent, UserDialogComponent],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    MatTableModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    ReactiveFormsModule
+  ]
+})
+export class UserAdminModule {}

--- a/votnet-client/src/app/user-admin/user-list.component.css
+++ b/votnet-client/src/app/user-admin/user-list.component.css
@@ -1,0 +1,1 @@
+table { width: 100%; margin-top: 16px; }

--- a/votnet-client/src/app/user-admin/user-list.component.html
+++ b/votnet-client/src/app/user-admin/user-list.component.html
@@ -1,0 +1,10 @@
+<button mat-raised-button color="primary" (click)="create()">New User</button>
+<table mat-table [dataSource]="users" class="mat-elevation-z8">
+  <ng-container matColumnDef="username">
+    <th mat-header-cell *matHeaderCellDef> Username </th>
+    <td mat-cell *matCellDef="let element"> {{element.username}} </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/votnet-client/src/app/user-admin/user-list.component.ts
+++ b/votnet-client/src/app/user-admin/user-list.component.ts
@@ -1,0 +1,66 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialog, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormBuilder, Validators } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+
+@Component({
+  selector: 'app-user-list',
+  templateUrl: './user-list.component.html'
+})
+export class UserListComponent {
+  displayedColumns = ['username'];
+  users: any[] = [];
+
+  constructor(private http: HttpClient, private dialog: MatDialog) {
+    this.load();
+  }
+
+  load(): void {
+    this.http.get<any[]>(`${environment.apiBaseUrl}/users`).subscribe(data => this.users = data);
+  }
+
+  create(): void {
+    const ref = this.dialog.open(UserDialogComponent);
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.load();
+      }
+    });
+  }
+}
+
+@Component({
+  selector: 'app-user-dialog',
+  template: `
+  <h1 mat-dialog-title>New User</h1>
+  <div mat-dialog-content>
+    <form [formGroup]="form">
+      <mat-form-field>
+        <mat-label>Username</mat-label>
+        <input matInput formControlName="username" />
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Password</mat-label>
+        <input matInput type="password" formControlName="password" />
+      </mat-form-field>
+    </form>
+  </div>
+  <div mat-dialog-actions>
+    <button mat-button (click)="dialogRef.close()">Cancel</button>
+    <button mat-raised-button color="primary" (click)="save()">Save</button>
+  </div>`
+})
+export class UserDialogComponent {
+  form = this.fb.group({
+    username: ['', Validators.required],
+    password: ['', Validators.required]
+  });
+
+  constructor(private fb: FormBuilder, private http: HttpClient, private dialogRef: MatDialogRef<UserDialogComponent>) {}
+
+  save(): void {
+    if (this.form.invalid) return;
+    this.http.post(`${environment.apiBaseUrl}/users`, this.form.value).subscribe(() => this.dialogRef.close(true));
+  }
+}

--- a/votnet-client/src/environments/environment.prod.ts
+++ b/votnet-client/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: '/api'
+};

--- a/votnet-client/src/environments/environment.ts
+++ b/votnet-client/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:5000/api'
+};

--- a/votnet-client/src/index.html
+++ b/votnet-client/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>VotNET</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/votnet-client/src/main.ts
+++ b/votnet-client/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/votnet-client/src/polyfills.ts
+++ b/votnet-client/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/votnet-client/src/styles.css
+++ b/votnet-client/src/styles.css
@@ -1,0 +1,3 @@
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
+html, body { height: 100%; margin: 0; }
+body { font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/votnet-client/src/test.ts
+++ b/votnet-client/src/test.ts
@@ -1,0 +1,12 @@
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+import 'zone.js/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/votnet-client/tsconfig.app.json
+++ b/votnet-client/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/votnet-client/tsconfig.json
+++ b/votnet-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2022", "dom"]
+  }
+}

--- a/votnet-client/tsconfig.spec.json
+++ b/votnet-client/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": [
+    "src/test.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Angular client with Material layout and routing
- implement auth service with JWT login and interceptor
- add user administration and election management modules with SignalR results
- document frontend setup and usage

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular-devkit%2fbuild-angular)*

------
https://chatgpt.com/codex/tasks/task_b_68ae249797048322bd2c4444a8e6a1ad