### PR TITLE
Enhance authentication and election workflow

### DIFF
--- a/votnet-client/src/app/app-routing.module.ts
+++ b/votnet-client/src/app/app-routing.module.ts
@@ -1,16 +1,20 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './login/login.component';
+import { AuthGuard } from './services/auth.guard';
 
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
   {
     path: 'users',
-    loadChildren: () => import('./user-admin/user-admin.module').then(m => m.UserAdminModule)
+    loadChildren: () => import('./user-admin/user-admin.module').then(m => m.UserAdminModule),
+    canLoad: [AuthGuard],
+    data: { roles: ['GlobalAdmin', 'VoteAdmin'] }
   },
   {
     path: 'elections',
-    loadChildren: () => import('./elections/elections.module').then(m => m.ElectionsModule)
+    loadChildren: () => import('./elections/elections.module').then(m => m.ElectionsModule),
+    canLoad: [AuthGuard]
   },
   { path: '', redirectTo: 'elections', pathMatch: 'full' }
 ];

--- a/votnet-client/src/app/app.module.ts
+++ b/votnet-client/src/app/app.module.ts
@@ -15,7 +15,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { LayoutComponent } from './layout/layout.component';
 import { LoginComponent } from './login/login.component';
-import { authInterceptor } from './services/auth.interceptor';
+import { AuthInterceptor } from './services/auth.interceptor';
 
 @NgModule({
   declarations: [AppComponent, LayoutComponent, LoginComponent],
@@ -34,7 +34,7 @@ import { authInterceptor } from './services/auth.interceptor';
     MatInputModule
   ],
   providers: [
-    { provide: HTTP_INTERCEPTORS, useValue: authInterceptor, multi: true }
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/votnet-client/src/app/elections/election-create.component.html
+++ b/votnet-client/src/app/elections/election-create.component.html
@@ -3,6 +3,18 @@
     <mat-label>Name</mat-label>
     <input matInput formControlName="name">
   </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Details</mat-label>
+    <textarea matInput formControlName="details"></textarea>
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Scheduled At</mat-label>
+    <input matInput type="datetime-local" formControlName="scheduledAt">
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Minimum Quorum</mat-label>
+    <input matInput type="number" formControlName="quorumMinimo">
+  </mat-form-field>
   <div formArrayName="questions">
     <div *ngFor="let q of questions.controls; let i = index" [formGroupName]="i">
       <h3>Question {{i + 1}}</h3>

--- a/votnet-client/src/app/elections/election-create.component.ts
+++ b/votnet-client/src/app/elections/election-create.component.ts
@@ -12,6 +12,9 @@ import { environment } from '../../environments/environment';
 export class ElectionCreateComponent {
   form = this.fb.group({
     name: ['', Validators.required],
+    details: [''],
+    scheduledAt: ['', Validators.required],
+    quorumMinimo: [0, [Validators.required, Validators.min(0)]],
     questions: this.fb.array([
       this.fb.group({
         text: ['', Validators.required],
@@ -46,6 +49,7 @@ export class ElectionCreateComponent {
   }
 
   submit(): void {
+    if (this.form.invalid) return;
     const election = this.form.value;
     this.http.post<any>(`${environment.apiBaseUrl}/elections`, election).subscribe(e => {
       if (this.padron) {

--- a/votnet-client/src/app/elections/results/results.component.html
+++ b/votnet-client/src/app/elections/results/results.component.html
@@ -3,8 +3,8 @@
   <div *ngFor="let q of r.questions">
     <h3>{{q.text}}</h3>
     <div *ngFor="let o of q.options">
-      <div>{{o.text}} - {{o.votes}}</div>
-      <mat-progress-bar [value]="o.votes"></mat-progress-bar>
+      <div>{{o.text}} - {{o.votes}} ({{ (q.totalVotes ? o.votes / q.totalVotes * 100 : 0) | number:'1.0-0' }}%)</div>
+      <mat-progress-bar [value]="q.totalVotes ? o.votes / q.totalVotes * 100 : 0"></mat-progress-bar>
     </div>
   </div>
 </div>

--- a/votnet-client/src/app/elections/results/results.component.ts
+++ b/votnet-client/src/app/elections/results/results.component.ts
@@ -22,6 +22,11 @@ export class ResultsComponent implements OnInit {
 
   load(): void {
     const id = this.route.snapshot.paramMap.get('id');
-    this.http.get(`${environment.apiBaseUrl}/elections/${id}/results`).subscribe(res => this.results = res);
+    this.http.get<any>(`${environment.apiBaseUrl}/elections/${id}/results`).subscribe(res => {
+      res.questions.forEach((q: any) => {
+        q.totalVotes = q.options.reduce((s: number, o: any) => s + o.votes, 0);
+      });
+      this.results = res;
+    });
   }
 }

--- a/votnet-client/src/app/layout/layout.component.html
+++ b/votnet-client/src/app/layout/layout.component.html
@@ -1,9 +1,10 @@
 <mat-sidenav-container class="sidenav-container">
   <mat-sidenav #drawer mode="side" opened>
     <mat-nav-list>
-      <a mat-list-item routerLink="/elections">Elections</a>
-      <a mat-list-item routerLink="/users">Users</a>
-      <a mat-list-item routerLink="/login">Login</a>
+      <a mat-list-item routerLink="/elections" *ngIf="auth.isLoggedIn">Elections</a>
+      <a mat-list-item routerLink="/users" *ngIf="auth.hasRole('GlobalAdmin') || auth.hasRole('VoteAdmin')">Users</a>
+      <a mat-list-item routerLink="/login" *ngIf="!auth.isLoggedIn">Login</a>
+      <a mat-list-item (click)="logout()" *ngIf="auth.isLoggedIn">Logout</a>
     </mat-nav-list>
   </mat-sidenav>
 

--- a/votnet-client/src/app/layout/layout.component.ts
+++ b/votnet-client/src/app/layout/layout.component.ts
@@ -1,8 +1,17 @@
 import { Component } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-layout',
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.css']
 })
-export class LayoutComponent {}
+export class LayoutComponent {
+  constructor(public auth: AuthService, private router: Router) {}
+
+  logout(): void {
+    this.auth.logout();
+    this.router.navigate(['/login']);
+  }
+}

--- a/votnet-client/src/app/login/login.component.css
+++ b/votnet-client/src/app/login/login.component.css
@@ -4,3 +4,8 @@
   width: 300px;
   margin: 32px auto;
 }
+
+.error {
+  color: red;
+  margin-bottom: 8px;
+}

--- a/votnet-client/src/app/login/login.component.html
+++ b/votnet-client/src/app/login/login.component.html
@@ -7,5 +7,6 @@
     <mat-label>Password</mat-label>
     <input matInput type="password" formControlName="password">
   </mat-form-field>
+  <div class="error" *ngIf="error">{{error}}</div>
   <button mat-raised-button color="primary" type="submit">Login</button>
 </form>

--- a/votnet-client/src/app/login/login.component.ts
+++ b/votnet-client/src/app/login/login.component.ts
@@ -18,8 +18,12 @@ export class LoginComponent {
 
   submit(): void {
     if (this.form.invalid) return;
-    this.auth.login(this.form.value as any).subscribe(() => {
-      this.router.navigate(['/']);
+    this.error = '';
+    this.auth.login(this.form.value as any).subscribe({
+      next: () => this.router.navigate(['/']),
+      error: () => (this.error = 'Invalid credentials')
     });
   }
+
+  error = '';
 }

--- a/votnet-client/src/app/services/auth.guard.ts
+++ b/votnet-client/src/app/services/auth.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, CanLoad, Route, UrlSegment, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate, CanLoad {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    return this.check(route.data['roles']);
+  }
+
+  canLoad(route: Route, segments: UrlSegment[]): boolean {
+    return this.check(route.data && (route.data as any)['roles']);
+  }
+
+  private check(roles?: string[]): boolean {
+    if (!this.auth.isLoggedIn) {
+      this.router.navigate(['/login']);
+      return false;
+    }
+    if (roles && !roles.some(r => this.auth.hasRole(r))) {
+      this.router.navigate(['/']);
+      return false;
+    }
+    return true;
+  }
+}

--- a/votnet-client/src/app/services/auth.service.ts
+++ b/votnet-client/src/app/services/auth.service.ts
@@ -1,28 +1,58 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { environment } from '../../environments/environment';
-import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { Observable, throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
 
 type LoginRequest = { username: string; password: string };
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly tokenKey = 'token';
+  private _token: string | null = null;
 
   constructor(private http: HttpClient) {}
 
-  login(data: LoginRequest): Observable<any> {
-    return this.http.post(`${environment.apiBaseUrl}/auth/login`, data, {
-      responseType: 'text'
-    }).pipe(tap(token => localStorage.setItem(this.tokenKey, token)));
+  login(data: LoginRequest): Observable<void> {
+    return this.http
+      .post<{ token: string }>(`${environment.apiBaseUrl}/auth/login`, data)
+      .pipe(
+        tap(res => {
+          this._token = res.token;
+          sessionStorage.setItem(this.tokenKey, res.token);
+        }),
+        catchError((err: HttpErrorResponse) => throwError(() => err))
+      );
   }
 
   get token(): string | null {
-    return localStorage.getItem(this.tokenKey);
+    return this._token ?? sessionStorage.getItem(this.tokenKey);
+  }
+
+  get isLoggedIn(): boolean {
+    return !!this.token;
+  }
+
+  private get payload(): any | null {
+    const token = this.token;
+    if (!token) return null;
+    try {
+      const base64 = token.split('.')[1];
+      return JSON.parse(atob(base64));
+    } catch {
+      return null;
+    }
+  }
+
+  hasRole(role: string): boolean {
+    const p = this.payload;
+    const roles = p?.role;
+    if (Array.isArray(roles)) return roles.includes(role);
+    return roles === role;
   }
 
   logout(): void {
-    localStorage.removeItem(this.tokenKey);
+    this._token = null;
+    sessionStorage.removeItem(this.tokenKey);
   }
 }


### PR DESCRIPTION
## Summary
- Parse JSON token on login, store in session, expose role checks, and add auth guard and interceptor
- Expand election creation to include details, schedule, and quorum with validation
- Show vote percentages and add logout with role-based navigation

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*


------
https://chatgpt.com/codex/tasks/task_b_68ae8da10f7c8322819b13732f0bca49