### PR TITLE
Downgrade Microsoft.OpenApi dependency

### DIFF
--- a/BvgAuthApi/BvgAuthApi.csproj
+++ b/BvgAuthApi/BvgAuthApi.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OpenApi" Version="2.2.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.23" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
     <PackageReference Include="EPPlus" Version="6.2.0" />


### PR DESCRIPTION
## Summary
- use Microsoft.OpenApi package version 1.6.23

## Testing
- `dotnet restore BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found: dotnet)*
- `dotnet run --project BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_b_68af193b6d5c8322b02032a20a4d3d3d