### PR TITLE
Read config secrets from environment

### DIFF
--- a/BvgAuthApi/Program.cs
+++ b/BvgAuthApi/Program.cs
@@ -13,6 +13,16 @@ using BvgAuthApi.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Replace placeholders with environment variables when available
+builder.Configuration["ConnectionStrings:Default"] =
+    Environment.GetEnvironmentVariable("DB_CONN") ?? builder.Configuration["ConnectionStrings:Default"];
+builder.Configuration["Jwt:Key"] =
+    Environment.GetEnvironmentVariable("JWT_KEY") ?? builder.Configuration["Jwt:Key"];
+builder.Configuration["Seed:AdminEmail"] =
+    Environment.GetEnvironmentVariable("ADMIN_EMAIL") ?? builder.Configuration["Seed:AdminEmail"];
+builder.Configuration["Seed:AdminPassword"] =
+    Environment.GetEnvironmentVariable("ADMIN_PASSWORD") ?? builder.Configuration["Seed:AdminPassword"];
+
 // DbContext
 builder.Services.AddDbContext<BvgDbContext>(opt =>
     opt.UseNpgsql(builder.Configuration.GetConnectionString("Default")));

--- a/BvgAuthApi/appsettings.json
+++ b/BvgAuthApi/appsettings.json
@@ -1,18 +1,19 @@
-﻿{
+{
   "ConnectionStrings": {
-    "Default": "Host=localhost;Port=5432;Database=bvg_auth;Username=bvg_user;Password=BVG2025"
+    "Default": "${DB_CONN}"
   },
   "Jwt": {
     "Issuer": "bvg-auth",
     "Audience": "bvg-portal",
-    "Key": "CambiaEstaClaveSuperSecretaDeAlMenos32Caracteres!!",
+    "Key": "${JWT_KEY}",
     "ExpiresMinutes": 120
   },
   "Seed": {
-    "AdminEmail": "admin@bvg.local",
-    "AdminPassword": "Admin!123"
+    "AdminEmail": "${ADMIN_EMAIL}",
+    "AdminPassword": "${ADMIN_PASSWORD}"
   },
   "AllowOrigins": [ "http://localhost:4200" ],
   "Logging": { "LogLevel": { "Default": "Information" } },
   "AllowedHosts": "*"
 }
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # VOTNET
+
+## Configuration
+
+Sensitive values are not stored in source control. The following placeholders in
+`BvgAuthApi/appsettings.json` must be provided at runtime through environment
+variables or a secrets manager:
+
+| Placeholder | Environment variable |
+|-------------|----------------------|
+| `${DB_CONN}` | `DB_CONN` |
+| `${JWT_KEY}` | `JWT_KEY` |
+| `${ADMIN_EMAIL}` | `ADMIN_EMAIL` |
+| `${ADMIN_PASSWORD}` | `ADMIN_PASSWORD` |
+
+Example configuration on Linux or macOS:
+
+```bash
+export DB_CONN="Host=localhost;Port=5432;Database=bvg_auth;Username=bvg_user;Password=secret"
+export JWT_KEY="change-this-key"
+export ADMIN_EMAIL="admin@bvg.local"
+export ADMIN_PASSWORD="S3cureP@ss"
+dotnet run --project BvgAuthApi
+```
+
+On Windows PowerShell replace `export` with `$env:VAR = "value"`.
+
+In production use a secrets manager or deployment environment to supply these
+values securely.
+


### PR DESCRIPTION
## Summary
- remove hard-coded connection string, JWT key, and seed credentials
- load configuration from DB_CONN, JWT_KEY, ADMIN_EMAIL and ADMIN_PASSWORD
- document secret configuration via environment variables

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found)*
- `wget https://dot.net/v1/dotnet-install.sh` *(download produced empty file; unable to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_b_68af22cde318832286ecb7e41e671635