### PR TITLE
feat(padron): edit shareholders from actions column

### DIFF
--- a/bvg-portal/src/app/features/elections/election-padron-edit.component.ts
+++ b/bvg-portal/src/app/features/elections/election-padron-edit.component.ts
@@ -8,8 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { ReactiveFormsModule, FormBuilder, Validators, FormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { AuthService } from '../../core/auth.service';
@@ -21,7 +20,7 @@ import { PadronRow, sortPadronByNumericId, canDeleteShareholder, getDeleteErrorM
   imports: [
     NgFor, NgIf, DecimalPipe, MatCardModule, MatFormFieldModule, MatInputModule, 
     MatButtonModule, MatTableModule, MatSnackBarModule, ReactiveFormsModule,
-    FormsModule, MatDialogModule, MatIconModule, MatTooltipModule
+    MatIconModule, MatTooltipModule
   ],
      template: `
    <div class="page">
@@ -84,116 +83,60 @@ import { PadronRow, sortPadronByNumericId, canDeleteShareholder, getDeleteErrorM
           
           <ng-container matColumnDef="name">
             <th mat-header-cell *matHeaderCellDef>Nombre</th>
+            <td mat-cell *matCellDef="let row">{{row.shareholderName}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="shares">
+            <th mat-header-cell *matHeaderCellDef>Cantidad de Acciones</th>
             <td mat-cell *matCellDef="let row">
-              <div *ngIf="!row.editing; else editName">
-                {{row.shareholderName}}
-                <button mat-icon-button (click)="startEdit(row, 'name')" class="edit-btn">
-                  <mat-icon>edit</mat-icon>
-                </button>
-              </div>
-                             <ng-template #editName>
-                 <mat-form-field appearance="outline" class="inline-form">
-                   <input matInput [(ngModel)]="row.editName" 
-                          (blur)="saveEdit(row, 'name')" 
-                          (keyup.enter)="saveEdit(row, 'name')"
-                          (keyup.escape)="cancelEdit(row, 'name')">
-                 </mat-form-field>
-               </ng-template>
+              <span class="shares-number">{{row.shares | number}}</span>
             </td>
           </ng-container>
-          
-                     <ng-container matColumnDef="shares">
-             <th mat-header-cell *matHeaderCellDef>Cantidad de Acciones</th>
-             <td mat-cell *matCellDef="let row">
-               <div *ngIf="!row.editingShares; else editShares" class="shares-cell">
-                 <span class="shares-number">{{row.shares | number}}</span>
-                 <button mat-icon-button (click)="startEdit(row, 'shares')" class="edit-btn">
-                   <mat-icon>edit</mat-icon>
-                 </button>
-               </div>
-               <ng-template #editShares>
-                 <mat-form-field appearance="outline" class="inline-form">
-                   <input matInput type="number" [(ngModel)]="row.editShares" 
-                          (blur)="saveEdit(row, 'shares')" 
-                          (keyup.enter)="saveEdit(row, 'shares')"
-                          (keyup.escape)="cancelEdit(row, 'shares')">
-                 </mat-form-field>
-               </ng-template>
-             </td>
-           </ng-container>
-          
+
           <ng-container matColumnDef="representative">
             <th mat-header-cell *matHeaderCellDef>Representante Legal</th>
-            <td mat-cell *matCellDef="let row">
-              <div *ngIf="!row.editingRep; else editRep">
-                {{row.legalRepresentative || '-'}}
-                <button mat-icon-button (click)="startEdit(row, 'representative')" class="edit-btn">
-                  <mat-icon>edit</mat-icon>
-                </button>
-              </div>
-                             <ng-template #editRep>
-                 <mat-form-field appearance="outline" class="inline-form">
-                   <input matInput [(ngModel)]="row.editRepresentative" 
-                          (blur)="saveEdit(row, 'representative')" 
-                          (keyup.enter)="saveEdit(row, 'representative')"
-                          (keyup.escape)="cancelEdit(row, 'representative')">
-                 </mat-form-field>
-               </ng-template>
-            </td>
+            <td mat-cell *matCellDef="let row">{{row.legalRepresentative || '-'}}</td>
           </ng-container>
-          
+
           <ng-container matColumnDef="proxy">
             <th mat-header-cell *matHeaderCellDef>Apoderado</th>
+            <td mat-cell *matCellDef="let row">{{row.proxy || '-'}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef>Acciones</th>
             <td mat-cell *matCellDef="let row">
-              <div *ngIf="!row.editingProxy; else editProxy">
-                {{row.proxy || '-'}}
-                <button mat-icon-button (click)="startEdit(row, 'proxy')" class="edit-btn">
+              <div class="actions-cell">
+                <button mat-icon-button color="primary" (click)="openEditDialog(row)" matTooltip="Editar accionista">
                   <mat-icon>edit</mat-icon>
                 </button>
+                <button mat-icon-button color="warn"
+                        (click)="deleteShareholder(row)"
+                        [disabled]="!this.canDeleteShareholder(row)"
+                        [matTooltip]="!this.canDeleteShareholder(row) ? 'No se puede eliminar: ya tiene asistencia registrada' : 'Eliminar accionista'">
+                  <mat-icon>delete</mat-icon>
+                </button>
               </div>
-                             <ng-template #editProxy>
-                 <mat-form-field appearance="outline" class="inline-form">
-                   <input matInput [(ngModel)]="row.editProxy" 
-                          (blur)="saveEdit(row, 'proxy')" 
-                          (keyup.enter)="saveEdit(row, 'proxy')"
-                          (keyup.escape)="cancelEdit(row, 'proxy')">
-                 </mat-form-field>
-               </ng-template>
             </td>
           </ng-container>
-          
-                     <ng-container matColumnDef="actions">
-             <th mat-header-cell *matHeaderCellDef>Acciones</th>
-             <td mat-cell *matCellDef="let row">
-               <div class="actions-cell">
-                 <button mat-icon-button color="warn" 
-                         (click)="deleteShareholder(row)" 
-                         [disabled]="!this.canDeleteShareholder(row)"
-                         [matTooltip]="!this.canDeleteShareholder(row) ? 'No se puede eliminar: ya tiene asistencia registrada' : 'Eliminar accionista'">
-                   <mat-icon>delete</mat-icon>
-                 </button>
-               </div>
-             </td>
-           </ng-container>
-          
-                                  <tr mat-header-row *matHeaderRowDef="columns"></tr>
-             <tr mat-row *matRowDef="let row; columns: columns;" 
-                 [class.editing]="row.editing || row.editingShares || row.editingRep || row.editingProxy"></tr>
-           </table>
-         </div>
-       </mat-card>
-     </div>
+
+          <tr mat-header-row *matHeaderRowDef="columns"></tr>
+          <tr mat-row *matRowDef="let row; columns: columns;"></tr>
+          </table>
+        </div>
+      </mat-card>
+    </div>
 
      <!-- Diálogo para agregar accionista -->
      <div class="add-dialog-overlay" *ngIf="showAddDialog" (click)="closeAddDialog()">
        <div class="add-dialog" (click)="$event.stopPropagation()">
          <div class="dialog-header">
-           <h3>Agregar Nuevo Accionista</h3>
+           <h3>{{ editingShareholder ? 'Editar Accionista' : 'Agregar Nuevo Accionista' }}</h3>
            <button mat-icon-button (click)="closeAddDialog()">
              <mat-icon>close</mat-icon>
            </button>
          </div>
-         
+
          <form [formGroup]="addForm" (ngSubmit)="submitAddShareholder()">
            <div class="form-row">
              <mat-form-field appearance="outline">
@@ -229,8 +172,8 @@ import { PadronRow, sortPadronByNumericId, canDeleteShareholder, getDeleteErrorM
            <div class="dialog-actions">
              <button mat-stroked-button type="button" (click)="closeAddDialog()">Cancelar</button>
              <button mat-raised-button color="primary" type="submit" [disabled]="!addForm.valid">
-               <mat-icon>add</mat-icon>
-               Agregar Accionista
+               <mat-icon>{{ editingShareholder ? 'save' : 'add' }}</mat-icon>
+               {{ editingShareholder ? 'Guardar Cambios' : 'Agregar Accionista' }}
              </button>
            </div>
          </form>
@@ -277,13 +220,6 @@ import { PadronRow, sortPadronByNumericId, canDeleteShareholder, getDeleteErrorM
           gap: 8px;
         }
         
-        .edit-btn { margin-left: 8px; }
-        .inline-form { width: 200px; }
-        .inline-form .mat-mdc-form-field-subscript-wrapper { display: none; }
-        .mat-mdc-form-field { margin: 0; }
-        .editing { background-color: #fff3e0; }
-        .edit-btn:hover { color: #1976d2; }
-        
         .no-data {
           text-align: center;
           padding: 40px 20px;
@@ -303,21 +239,16 @@ import { PadronRow, sortPadronByNumericId, canDeleteShareholder, getDeleteErrorM
           border-radius: 4px;
         }
         
-        .shares-cell {
-          display: flex;
-          align-items: center;
-          gap: 8px;
-        }
-        
         .shares-number {
           font-weight: 500;
           color: #388e3c;
           min-width: 60px;
         }
-        
+
         .actions-cell {
           display: flex;
           justify-content: center;
+          gap: 8px;
         }
         
         /* Diálogo de agregar accionista */
@@ -404,7 +335,6 @@ export class ElectionPadronEditComponent {
   private router = inject(Router);
   private snack = inject(MatSnackBar);
   private auth = inject(AuthService);
-  private dialog = inject(MatDialog);
   private fb = inject(FormBuilder);
 
   id = signal<string>('');
@@ -412,6 +342,7 @@ export class ElectionPadronEditComponent {
   dataSource = new MatTableDataSource<PadronRow>([]);
   columns = ['id', 'name', 'shares', 'representative', 'proxy', 'actions'];
   showAddDialog = false;
+  editingShareholder: PadronRow | null = null;
   addForm = this.fb.group({
     shareholderId: ['', [Validators.required]],
     shareholderName: ['', [Validators.required]],
@@ -458,89 +389,6 @@ export class ElectionPadronEditComponent {
     });
   }
 
-  startEdit(row: PadronRow, field: string) {
-    // Limpiar otros campos de edición
-    this.padron().forEach(r => {
-      r.editing = false;
-      r.editingShares = false;
-      r.editingRep = false;
-      r.editingProxy = false;
-    });
-
-    // Activar el campo específico
-    switch (field) {
-      case 'name':
-        row.editing = true;
-        row.editName = row.shareholderName;
-        break;
-      case 'shares':
-        row.editingShares = true;
-        row.editShares = row.shares;
-        break;
-      case 'representative':
-        row.editingRep = true;
-        row.editRepresentative = row.legalRepresentative || '';
-        break;
-      case 'proxy':
-        row.editingProxy = true;
-        row.editProxy = row.proxy || '';
-        break;
-    }
-
-    // Forzar actualización de la señal para que Angular detecte los cambios
-    this.padron.set([...this.padron()]);
-    this.dataSource.data = [...this.padron()];
-  }
-
-  saveEdit(row: PadronRow, field: string) {
-    const updateData: any = { id: row.id };
-
-    switch (field) {
-      case 'name':
-        if (row.editName && row.editName.trim() !== row.shareholderName) {
-          updateData.shareholderName = row.editName.trim();
-          row.shareholderName = row.editName.trim();
-        }
-        row.editing = false;
-        break;
-      case 'shares':
-        if (row.editShares !== undefined && row.editShares !== row.shares) {
-          updateData.shares = row.editShares;
-          row.shares = row.editShares;
-        }
-        row.editingShares = false;
-        break;
-      case 'representative':
-        if (row.editRepresentative !== undefined && row.editRepresentative !== (row.legalRepresentative || '')) {
-          updateData.legalRepresentative = row.editRepresentative.trim();
-          row.legalRepresentative = row.editRepresentative.trim();
-        }
-        row.editingRep = false;
-        break;
-      case 'proxy':
-        if (row.editProxy !== undefined && row.editProxy !== (row.proxy || '')) {
-          updateData.proxy = row.editProxy.trim();
-          row.proxy = row.editProxy.trim();
-        }
-        row.editingProxy = false;
-        break;
-    }
-
-    // Forzar actualización de la señal para que Angular detecte los cambios
-    this.padron.set([...this.padron()]);
-    this.dataSource.data = [...this.padron()];
-
-    if (Object.keys(updateData).length > 1) { // Más que solo el ID
-      this.http.put(`/api/elections/${this.id()}/padron/${row.id}`, updateData).subscribe({
-        next: _ => this.snack.open('Accionista actualizado correctamente', 'OK', { duration: 1500 }),
-        error: err => {
-          console.error('Error updating shareholder:', err);
-          this.snack.open('Error al actualizar accionista. Intente nuevamente.', 'OK', { duration: 3000 });
-        }
-      });
-    }
-  }
-
   deleteShareholder(row: PadronRow) {
     if (!canDeleteShareholder(row)) {
       const errorMessage = getDeleteErrorMessage(row);
@@ -567,68 +415,74 @@ export class ElectionPadronEditComponent {
   }
 
   openAddDialog() {
-    this.showAddDialog = true;
+    this.editingShareholder = null;
     this.addForm.reset({
+      shareholderId: '',
+      shareholderName: '',
       shares: 0,
       legalRepresentative: '',
       proxy: ''
     });
+    this.addForm.get('shareholderId')?.enable();
+    this.showAddDialog = true;
+  }
+
+  openEditDialog(row: PadronRow) {
+    this.editingShareholder = row;
+    this.addForm.reset({
+      shareholderId: row.shareholderId,
+      shareholderName: row.shareholderName,
+      shares: row.shares,
+      legalRepresentative: row.legalRepresentative || '',
+      proxy: row.proxy || ''
+    });
+    this.addForm.get('shareholderId')?.disable();
+    this.showAddDialog = true;
   }
 
   closeAddDialog() {
     this.showAddDialog = false;
     this.addForm.reset();
+    this.addForm.get('shareholderId')?.enable();
+    this.editingShareholder = null;
   }
 
   submitAddShareholder() {
     if (this.addForm.valid) {
-      const newShareholder = this.addForm.value;
-      
-      // Verificar si el ID ya existe
-      const existingId = this.padron().find(s => s.shareholderId === newShareholder.shareholderId);
-      if (existingId) {
-        this.snack.open('Ya existe un accionista con ese ID', 'OK', { duration: 3000 });
-        return;
-      }
+      const formValue = this.addForm.getRawValue();
 
-      this.http.post(`/api/elections/${this.id()}/padron`, newShareholder).subscribe({
-        next: _ => {
-          this.snack.open('Accionista agregado correctamente', 'OK', { duration: 1500 });
-          this.closeAddDialog();
-          this.loadPadron();
-        },
-        error: err => {
-          console.error('Error adding shareholder:', err);
-          this.snack.open('Error al agregar accionista. Intente nuevamente.', 'OK', { duration: 3000 });
+      if (this.editingShareholder) {
+        this.http.put(`/api/elections/${this.id()}/padron/${this.editingShareholder.id}`, formValue).subscribe({
+          next: _ => {
+            this.snack.open('Accionista actualizado correctamente', 'OK', { duration: 1500 });
+            this.closeAddDialog();
+            this.loadPadron();
+          },
+          error: err => {
+            console.error('Error updating shareholder:', err);
+            this.snack.open('Error al actualizar accionista. Intente nuevamente.', 'OK', { duration: 3000 });
+          }
+        });
+      } else {
+        const existingId = this.padron().find(s => s.shareholderId === formValue.shareholderId);
+        if (existingId) {
+          this.snack.open('Ya existe un accionista con ese ID', 'OK', { duration: 3000 });
+          return;
         }
-      });
-    }
-  }
 
-  cancelEdit(row: PadronRow, field: string) {
-    // Cancelar la edición y restaurar valores originales
-    switch (field) {
-      case 'name':
-        row.editing = false;
-        row.editName = undefined;
-        break;
-      case 'shares':
-        row.editingShares = false;
-        row.editShares = undefined;
-        break;
-      case 'representative':
-        row.editingRep = false;
-        row.editRepresentative = undefined;
-        break;
-      case 'proxy':
-        row.editingProxy = false;
-        row.editProxy = undefined;
-        break;
+        this.http.post(`/api/elections/${this.id()}/padron`, formValue).subscribe({
+          next: _ => {
+            this.snack.open('Accionista agregado correctamente', 'OK', { duration: 1500 });
+            this.closeAddDialog();
+            this.loadPadron();
+          },
+          error: err => {
+            console.error('Error adding shareholder:', err);
+            this.snack.open('Error al agregar accionista. Intente nuevamente.', 'OK', { duration: 3000 });
+          }
+        });
+      }
     }
-    
-    // Forzar actualización de la señal
-    this.padron.set([...this.padron()]);
-    this.dataSource.data = [...this.padron()];
   }
 
   debugData() {

--- a/bvg-portal/src/app/shared/utils/padron.utils.ts
+++ b/bvg-portal/src/app/shared/utils/padron.utils.ts
@@ -2,19 +2,10 @@ export interface PadronRow {
   id: string; 
   shareholderId: string; 
   shareholderName: string; 
-  shares: number; 
+  shares: number;
   attendance: string;
   legalRepresentative?: string;
   proxy?: string;
-  // Campos de edición inline
-  editing?: boolean;
-  editingShares?: boolean;
-  editingRep?: boolean;
-  editingProxy?: boolean;
-  editName?: string;
-  editShares?: number;
-  editRepresentative?: string;
-  editProxy?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- reuse add shareholder form for editing existing entries
- centralize edit and delete controls in padrón table
- streamline PadronRow interface

## Testing
- `npm test` (fails: Cannot determine project or target for command)
- `npm run build` (fails: Failed to inline external stylesheet, status code 403)


------
https://chatgpt.com/codex/tasks/task_b_68b6040c9b38832288b4f359882fd491