### PR TITLE
feat: show share totals and simplify attendance control

### DIFF
--- a/bvg-portal/src/app/features/attendance/attendance-register.component.ts
+++ b/bvg-portal/src/app/features/attendance/attendance-register.component.ts
@@ -12,7 +12,16 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { AuthService } from '../../core/auth.service';
 
-interface PadronRow { id:string; shareholderId:string; shareholderName:string; shares:number; attendance:string }
+interface PadronRow {
+  id: string;
+  shareholderId: string;
+  shareholderName: string;
+  legalRepresentative?: string;
+  proxy?: string;
+  shares: number;
+  attendance: string;
+  hasActa?: boolean;
+}
 
 @Component({
   selector: 'app-attendance-register',
@@ -28,13 +37,15 @@ interface PadronRow { id:string; shareholderId:string; shareholderName:string; s
           <div class="center">
             <div class="num">{{presentCount()+virtualCount()}}</div>
             <div class="sub">Presentes</div>
+            <div class="num shares">{{presentShares()+virtualShares()}}</div>
+            <div class="sub">Acciones</div>
           </div>
         </div>
       </div>
       <div class="legend">
-        <span class="item"><span class="box presencial"></span> Presencial: {{presentCount()}}</span>
-        <span class="item"><span class="box virtual"></span> Virtual: {{virtualCount()}}</span>
-        <span class="item"><span class="box ausente"></span> Ausente: {{absentCount()}}</span>
+        <span class="item"><span class="box presencial"></span> Presencial: {{presentCount()}} personas / {{presentShares()}} acciones</span>
+        <span class="item"><span class="box virtual"></span> Virtual: {{virtualCount()}} personas / {{virtualShares()}} acciones</span>
+        <span class="item"><span class="box ausente"></span> Ausente: {{absentCount()}} personas / {{absentShares()}} acciones</span>
       </div>
     </div>
     <div class="toolbar">
@@ -51,14 +62,40 @@ interface PadronRow { id:string; shareholderId:string; shareholderName:string; s
       <div class="bar"><div class="p" [style.width.%]="presentPct()"></div></div>
     </div>
     <table mat-table [dataSource]="rows()" class="mat-elevation-z1 compact" *ngIf="rows().length">
-      <ng-container matColumnDef="sel"><th mat-header-cell *matHeaderCellDef></th><td mat-cell *matCellDef="let r"><mat-checkbox [(ngModel)]="selected[r.id]"></mat-checkbox></td></ng-container>
-      <ng-container matColumnDef="id"><th mat-header-cell *matHeaderCellDef>ID</th><td mat-cell *matCellDef="let r">{{r.shareholderId}}</td></ng-container>
-      <ng-container matColumnDef="name"><th mat-header-cell *matHeaderCellDef>Accionista</th><td mat-cell *matCellDef="let r">{{r.shareholderName}}</td></ng-container>
-      <ng-container matColumnDef="att"><th mat-header-cell *matHeaderCellDef>Asistencia</th><td mat-cell *matCellDef="let r">
-        <button mat-button [disabled]="locked || r.attendance==='Presencial'" [matTooltip]="disableReasonFor(r,'Presencial')" (click)="set(r,'Presencial')">Presencial</button>
-        <button mat-button [disabled]="locked || r.attendance==='Virtual'" [matTooltip]="disableReasonFor(r,'Virtual')" (click)="set(r,'Virtual')">Virtual</button>
-        <button mat-button [disabled]="locked || r.attendance==='None'" [matTooltip]="disableReasonFor(r,'None')" (click)="set(r,'None')">Ausente</button>
-      </td></ng-container>
+      <ng-container matColumnDef="sel">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let r"><mat-checkbox [(ngModel)]="selected[r.id]"></mat-checkbox></td>
+      </ng-container>
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let r">{{r.shareholderId}}</td>
+      </ng-container>
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Accionista</th>
+        <td mat-cell *matCellDef="let r">{{r.shareholderName}}</td>
+      </ng-container>
+      <ng-container matColumnDef="legal">
+        <th mat-header-cell *matHeaderCellDef>Representante</th>
+        <td mat-cell *matCellDef="let r">{{ r.legalRepresentative || '-' }}</td>
+      </ng-container>
+      <ng-container matColumnDef="proxy">
+        <th mat-header-cell *matHeaderCellDef>Apoderado</th>
+        <td mat-cell *matCellDef="let r">
+          <a *ngIf="r.proxy && r.hasActa" (click)="view(r)" class="link">{{ r.proxy }}</a>
+          <span *ngIf="r.proxy && !r.hasActa">{{ r.proxy }}</span>
+          <span *ngIf="!r.proxy">-</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="att">
+        <th mat-header-cell *matHeaderCellDef>Asistencia</th>
+        <td mat-cell *matCellDef="let r">
+          <mat-select [value]="r.attendance" (selectionChange)="set(r,$event.value)" [disabled]="locked">
+            <mat-option value="Presencial">Presencial</mat-option>
+            <mat-option value="Virtual">Virtual</mat-option>
+            <mat-option value="None">Ausente</mat-option>
+          </mat-select>
+        </td>
+      </ng-container>
       <tr mat-header-row *matHeaderRowDef="cols"></tr>
       <tr mat-row *matRowDef="let row; columns: cols;"></tr>
     </table>
@@ -72,6 +109,7 @@ interface PadronRow { id:string; shareholderId:string; shareholderName:string; s
     .donut .hole{ position:absolute; inset:18px; background:#fff; border-radius:50%; display:flex; align-items:center; justify-content:center }
     .donut .center{ text-align:center; line-height:1 }
     .donut .num{ font-size:20px; font-weight:600 }
+    .donut .num.shares{ font-size:14px; margin-top:4px }
     .donut .sub{ font-size:11px; opacity:.75 }
     .legend{ display:flex; gap:12px; flex-wrap:wrap; font-size:13px; opacity:.95 }
     .legend .box{ display:inline-block; width:12px; height:12px; border-radius:3px; margin-right:6px }
@@ -84,6 +122,7 @@ interface PadronRow { id:string; shareholderId:string; shareholderName:string; s
     .bar{ height:6px; border-radius:4px; background:#eee; overflow:hidden; margin-top:4px; max-width:320px }
     .bar .p{ height:100%; background: var(--bvg-blue) }
     table.compact th, table.compact td{ font-size:13px }
+    .link{ color: var(--bvg-blue); cursor:pointer; text-decoration:underline }
     .muted{ opacity:.75 }
   `]
 })
@@ -95,7 +134,7 @@ export class AttendanceRegisterComponent{
   auth = inject(AuthService);
   locked = false;
   id = this.route.snapshot.params['id'];
-  cols = ['sel','id','name','att'];
+  cols = ['sel','id','name','legal','proxy','att'];
   rows = signal<PadronRow[]>([]);
   bulkStatus: 'Presencial'|'Virtual'|'None' = 'Presencial';
   selected: Record<string, boolean> = {};
@@ -113,9 +152,9 @@ export class AttendanceRegisterComponent{
     this.live.onAttendanceSummary(_ => {/* donut recalculates from rows; no-op */});
     this.live.onAttendanceLockChanged(p => { if (p && p.ElectionId === this.id) this.locked = p.Locked; });
   }
-  load(){ 
-    this.http.get<PadronRow[]>(`/api/elections/${this.id}/padron`).subscribe({ 
-      next: d=> { 
+  load(){
+    this.http.get<PadronRow[]>(`/api/elections/${this.id}/padron`).subscribe({
+      next: d=> {
         // Ordenar por ID de accionista numéricamente
         const sortedData = (d || []).sort((a, b) => {
           const aNum = parseInt(a.shareholderId) || 0;
@@ -125,12 +164,25 @@ export class AttendanceRegisterComponent{
         this.rows.set(sortedData); 
         this.selected = {}; 
       }, 
-      error: _=> this.rows.set([]) 
-    }); 
+      error: _=> this.rows.set([])
+    });
+  }
+  view(r: PadronRow){
+    this.http.get(`/api/elections/${this.id}/padron/${r.id}/acta`, { responseType: 'blob' as 'json' }).subscribe({
+      next: (data:any) => {
+        const blob = data as Blob; const url = URL.createObjectURL(blob);
+        window.open(url, '_blank');
+        setTimeout(()=> URL.revokeObjectURL(url), 15000);
+      },
+      error: _ => this.snack.open('No se pudo abrir el PDF','OK',{duration:2000})
+    });
   }
   presentCount(){ return this.rows().filter(r=>r.attendance==='Presencial').length; }
   virtualCount(){ return this.rows().filter(r=>r.attendance==='Virtual').length; }
   absentCount(){ return this.rows().filter(r=>r.attendance==='None').length; }
+  presentShares(){ return this.rows().filter(r=>r.attendance==='Presencial').reduce((s,r)=>s+r.shares,0); }
+  virtualShares(){ return this.rows().filter(r=>r.attendance==='Virtual').reduce((s,r)=>s+r.shares,0); }
+  absentShares(){ return this.rows().filter(r=>r.attendance==='None').reduce((s,r)=>s+r.shares,0); }
   chartStyle(){
     const total = this.rows().length || 1;
     const p = Math.round(this.presentCount()/total*100);
@@ -185,15 +237,5 @@ export class AttendanceRegisterComponent{
         if (err && err.status === 403) return 'Acceso denegado.';
         return 'Ocurrió un error al actualizar la asistencia.';
     }
-  }
-
-  disableReasonFor(row: PadronRow, attendanceType: 'Presencial'|'Virtual'|'None'): string {
-    if (this.locked) {
-      return 'Asistencia cerrada';
-    }
-    if (row.attendance === attendanceType) {
-      return 'Ya marcado como ' + attendanceType;
-    }
-    return '';
   }
 }


### PR DESCRIPTION
## Summary
- display share totals for each attendance state and overall present
- replace attendance buttons with a single toggle control
- include representative and proxy info with direct link to proxy PDF

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_b_68b607a687188322aa555b4ef40f38af