### PR TITLE
fix: restore attendance register methods

### DIFF
--- a/bvg-portal/src/app/features/attendance/attendance-register.component.ts
+++ b/bvg-portal/src/app/features/attendance/attendance-register.component.ts
@@ -208,7 +208,11 @@ export class AttendanceRegisterComponent{
     });
   }
   markSelected(){
-@@ -164,36 +216,26 @@ export class AttendanceRegisterComponent{
+    if (this.locked) { this.snack.open('Asistencia cerrada','OK',{duration:1500}); return; }
+    const ids = Object.keys(this.selected).filter(k=>this.selected[k]); if(!ids.length) return;
+    if(!confirm(`Aplicar "${this.bulkStatus}" a ${ids.length} seleccionados?`)) return;
+    this.http.post(`/api/elections/${this.id}/attendance/batch`, { attendance: (this.bulkStatus === 'Presencial' ? 2 : (this.bulkStatus === 'Virtual' ? 1 : 0)), ids }).subscribe({
+      next: _=> { this.snack.open('Seleccionados actualizados','OK',{duration:1200}); this.load(); },
       error: err => this.snack.open(this.mapAttendanceError(err), 'OK', { duration: 2200 })
     });
   }


### PR DESCRIPTION
## Summary
- fix attendance register component methods and helpers
- reinstate toggleLock and error mapping logic

## Testing
- `NG_BUILD_NO_INLINE_FONTS=1 npm start`
- `npm run build` *(fails: Inlining of fonts failed. https://fonts.googleapis.com/... returned status code: 403.)*
- `npm test` *(fails: Cannot determine project or target for command.)*


------
https://chatgpt.com/codex/tasks/task_b_68b61ee3a7188322a5b37f203db35b5d