### PR TITLE
Use ElectionRegistrar role and load elections based on user role

### DIFF
--- a/BvgAuthApi/Endpoints/ElectionEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ElectionEndpoints.cs
@@ -144,7 +144,7 @@ namespace BvgAuthApi.Endpoints
                 var election = await db.Elections.FindAsync(id);
                 if (election is null) return Results.NotFound();
                 // Allow only per-election roles
-                var allowed = new[] { AppRoles.ElectionRegistrar, AppRoles.ElectionObserver, AppRoles.ElectionVoter, AppRoles.VoteOperator };
+                var allowed = new[] { AppRoles.ElectionRegistrar, AppRoles.ElectionObserver, AppRoles.ElectionVoter };
                 if (!allowed.Contains(dto.Role))
                     return Results.Json(new { error = "invalid_assignment_role" }, statusCode: 400);
                 db.ElectionUserAssignments.Add(new ElectionUserAssignment
@@ -445,7 +445,7 @@ namespace BvgAuthApi.Endpoints
                 static IResult Err(string code, int status) => Results.Json(new { error = code }, statusCode: status);
                 var userId = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value ?? user.FindFirst("sub")?.Value ?? "";
                 var isAdmin = user.IsInRole(AppRoles.GlobalAdmin) || user.IsInRole(AppRoles.VoteAdmin);
-                if (!isAdmin && !await db.ElectionUserAssignments.AnyAsync(a => a.ElectionId == id && a.UserId == userId && (a.Role == AppRoles.ElectionRegistrar || a.Role == AppRoles.VoteOperator)))
+                if (!isAdmin && !await db.ElectionUserAssignments.AnyAsync(a => a.ElectionId == id && a.UserId == userId && (a.Role == AppRoles.ElectionRegistrar)))
                     return Err("forbidden", 403);
                 var election = await db.Elections.Include(e => e.Padron).Include(e => e.Votes).FirstOrDefaultAsync(e => e.Id == id);
                 if (election is null) return Err("election_not_found", 404);

--- a/BvgAuthApi/Models/AppModels.cs
+++ b/BvgAuthApi/Models/AppModels.cs
@@ -5,7 +5,6 @@
         public const string GlobalAdmin = "GlobalAdmin";
         public const string VoteAdmin   = "VoteAdmin";
         public const string Functional  = "Functional";
-        public const string VoteOperator= "VoteOperator";
         public const string ElectionRegistrar = "ElectionRegistrar";
         public const string ElectionObserver  = "ElectionObserver";
         public const string ElectionVoter     = "ElectionVoter";

--- a/BvgAuthApi/Program.cs
+++ b/BvgAuthApi/Program.cs
@@ -119,7 +119,6 @@ builder.Services.AddAuthorization(opt =>
 {
     opt.AddPolicy(AppRoles.GlobalAdmin, p => p.RequireRole(AppRoles.GlobalAdmin));
     opt.AddPolicy(AppRoles.VoteAdmin,   p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin));
-    opt.AddPolicy(AppRoles.VoteOperator,p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.VoteOperator));
     opt.AddPolicy(AppRoles.ElectionRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionRegistrar));
     opt.AddPolicy(AppRoles.ElectionObserver,  p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionObserver));
     opt.AddPolicy(AppRoles.ElectionVoter,     p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionVoter));

--- a/bvg-portal/src/app/features/attendance/attendance-list.component.ts
+++ b/bvg-portal/src/app/features/attendance/attendance-list.component.ts
@@ -4,6 +4,7 @@ import { NgIf, NgFor, DatePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { Router } from '@angular/router';
+import { AuthService } from '../../core/auth.service';
 
 interface AssignedDto { id: string; name: string; scheduledAt: string; isClosed: boolean; }
 
@@ -39,9 +40,13 @@ interface AssignedDto { id: string; name: string; scheduledAt: string; isClosed:
 export class AttendanceListComponent {
   private http = inject(HttpClient);
   private router = inject(Router);
+  private auth = inject(AuthService);
   items = signal<AssignedDto[]>([]);
   constructor(){ this.load(); }
-  load(){ this.http.get<AssignedDto[]>(`/api/elections/assigned?role=ElectionRegistrar`).subscribe({ next: d=> this.items.set(d||[]), error: _=> this.items.set([]) }); }
+  load(){
+    const role = this.auth.roles.find(r => ['ElectionRegistrar','ElectionVoter','ElectionObserver'].includes(r)) || 'ElectionRegistrar';
+    this.http.get<AssignedDto[]>(`/api/elections/assigned?role=${role}`).subscribe({ next: d=> this.items.set(d||[]), error: _=> this.items.set([]) });
+  }
   goReq(id: string){ this.router.navigate(['/attendance', id, 'requirements']); }
   goReg(id: string){ this.router.navigate(['/attendance', id, 'register']); }
 }

--- a/bvg-portal/src/app/features/dashboard/dashboard.component.ts
+++ b/bvg-portal/src/app/features/dashboard/dashboard.component.ts
@@ -111,7 +111,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private loadElections(){
     const isAdmin = this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin');
-    const url = isAdmin ? '/api/elections' : '/api/elections/assigned?role=ElectionRegistrar';
+    let url = '/api/elections';
+    if (!isAdmin) {
+      const role = this.auth.roles.find(r => ['ElectionRegistrar','ElectionVoter','ElectionObserver'].includes(r)) || 'ElectionRegistrar';
+      url = `/api/elections/assigned?role=${role}`;
+    }
     this.http.get<any[]>(url).subscribe({
       next: list => {
         const now = new Date();

--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -389,7 +389,7 @@ export class ElectionDetailComponent implements AfterViewInit {
     return (this.assignments()||[]).some((a:any) => (a.userId ?? a.UserId) === me && (a.role ?? a.Role) === 'ElectionRegistrar');
   }
   get canRegister(){
-    return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin') || this.auth.hasRole('VoteOperator');
+    return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin') || this.auth.hasRole('ElectionRegistrar');
   }
   get canClose(){ return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin'); }
 }

--- a/bvg-portal/src/app/features/elections/election-wizard.component.ts
+++ b/bvg-portal/src/app/features/elections/election-wizard.component.ts
@@ -257,7 +257,7 @@ export class ElectionWizardComponent {
     this.step1.patchValue({ scheduledAt: out.toISOString() });
   }
   applyAttendance(){ const users = this.selectedUsersAttendance.value || []; if (!users.length) return; this.assignments.set([...this.assignments(), ...users.map(u=>({user:u, role:'ElectionRegistrar'}))]); this.selectedUsersAttendance.setValue([]); }
-  applyVoting(){ const users = this.selectedUsersVoting.value || []; if (!users.length) return; this.assignments.set([...this.assignments(), ...users.map(u=>({user:u, role:'VoteOperator'}))]); this.selectedUsersVoting.setValue([]); }
+  applyVoting(){ const users = this.selectedUsersVoting.value || []; if (!users.length) return; this.assignments.set([...this.assignments(), ...users.map(u=>({user:u, role:'ElectionRegistrar'}))]); this.selectedUsersVoting.setValue([]); }
   removeAssignment(i:number){ const copy = [...this.assignments()]; copy.splice(i,1); this.assignments.set(copy); }
 
   async create(){


### PR DESCRIPTION
## Summary
- Assign voting registrars with the ElectionRegistrar role and remove leftover VoteOperator references
- Query assigned elections according to the authenticated user's role in dashboard and attendance list

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: unknown arguments)*

------
https://chatgpt.com/codex/tasks/task_b_68b6f42a02e483228b3cbad8e34bf99f