### PR TITLE
Add Azure AD environment typings

### DIFF
--- a/bvg-portal/src/environments.ts
+++ b/bvg-portal/src/environments.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  azureClientId: import.meta.env['NG_APP_AZURE_AD_CLIENT_ID'] || '',
-  azureTenantId: import.meta.env['NG_APP_AZURE_AD_TENANT_ID'] || '',
-  azureRedirectUri: import.meta.env['NG_APP_AZURE_AD_REDIRECT_URI'] || window.location.origin
+  azureClientId: import.meta.env.NG_APP_AZURE_AD_CLIENT_ID || '',
+  azureTenantId: import.meta.env.NG_APP_AZURE_AD_TENANT_ID || '',
+  azureRedirectUri: import.meta.env.NG_APP_AZURE_AD_REDIRECT_URI || window.location.origin
 };

--- a/bvg-portal/src/import-meta-env.d.ts
+++ b/bvg-portal/src/import-meta-env.d.ts
@@ -1,0 +1,9 @@
+interface ImportMetaEnv {
+  readonly NG_APP_AZURE_AD_CLIENT_ID: string;
+  readonly NG_APP_AZURE_AD_TENANT_ID: string;
+  readonly NG_APP_AZURE_AD_REDIRECT_URI: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add ImportMetaEnv declaration for Azure AD env vars
- use typed `import.meta.env` access in environment config

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@azure%2fmsal-browser)*
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_b_68b6fa536b108322b56b6023b04e96d0