### PR TITLE
Fix quorum update casing and restore number pipe

### DIFF
--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -269,7 +269,11 @@ export class ElectionDetailComponent implements AfterViewInit {
     this.loadQuorum();
     this.loadElectionInfo();
     this.live.onVoteRegistered(()=> { this.loadResults(); this.loadQuorum(); });
-    this.live.onQuorumUpdated(p => { if (p && p.ElectionId === this.id()) this.quorum.set({ total: p.TotalShares || p.totalShares, present: p.PresentShares || p.presentShares, quorum: p.Quorum || p.quorum }); });
+    this.live.onQuorumUpdated(p => {
+      if (p && p.ElectionId === this.id()) {
+        this.quorum.set({ total: p.TotalShares, present: p.PresentShares, quorum: p.Quorum });
+      }
+    });
     if (this.editMode()) this.prefillEdit();
   }
   ngAfterViewInit(){

--- a/bvg-portal/src/app/features/elections/results-live.component.ts
+++ b/bvg-portal/src/app/features/elections/results-live.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { NgFor, NgIf } from '@angular/common';
+import { NgFor, NgIf, DecimalPipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
@@ -10,7 +10,7 @@ import { LiveService } from '../../core/live.service';
 @Component({
   selector: 'app-results-live',
   standalone: true,
-  imports: [NgFor, NgIf, MatCardModule, MatFormFieldModule, MatSelectModule, MatTableModule],
+  imports: [NgFor, NgIf, DecimalPipe, MatCardModule, MatFormFieldModule, MatSelectModule, MatTableModule],
   template: `
   <div class="page">
     <h2>Resultados en vivo</h2>


### PR DESCRIPTION
## Summary
- Use correct casing for quorum update data in election-detail component
- Import DecimalPipe to enable `number` pipe in results-live component

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run build` *(fails: Could not resolve '@azure/msal-browser'; Failed to inline external stylesheet)*

------
https://chatgpt.com/codex/tasks/task_b_68b70d91d0948322ae2febd2d020b38a