### PR TITLE
Remove ElectionVoter subrole

### DIFF
--- a/BvgAuthApi/Endpoints/ElectionEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ElectionEndpoints.cs
@@ -144,7 +144,7 @@ namespace BvgAuthApi.Endpoints
                 var election = await db.Elections.FindAsync(id);
                 if (election is null) return Results.NotFound();
                 // Allow only per-election roles
-                var allowed = new[] { AppRoles.AttendanceRegistrar, AppRoles.VoteRegistrar, AppRoles.ElectionObserver, AppRoles.ElectionVoter };
+                var allowed = new[] { AppRoles.AttendanceRegistrar, AppRoles.VoteRegistrar, AppRoles.ElectionObserver };
                 if (!allowed.Contains(dto.Role))
                     return Results.Json(new { error = "invalid_assignment_role" }, statusCode: 400);
                 db.ElectionUserAssignments.Add(new ElectionUserAssignment

--- a/BvgAuthApi/Models/AppModels.cs
+++ b/BvgAuthApi/Models/AppModels.cs
@@ -9,7 +9,6 @@
         public const string AttendanceRegistrar = "AttendanceRegistrar";
         public const string VoteRegistrar = "VoteRegistrar";
         public const string ElectionObserver  = "ElectionObserver";
-        public const string ElectionVoter     = "ElectionVoter";
     }
 
     public class Election

--- a/BvgAuthApi/Program.cs
+++ b/BvgAuthApi/Program.cs
@@ -126,7 +126,6 @@ builder.Services.AddAuthorization(opt =>
     opt.AddPolicy(AppRoles.AttendanceRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.AttendanceRegistrar));
     opt.AddPolicy(AppRoles.VoteRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.VoteRegistrar));
     opt.AddPolicy(AppRoles.ElectionObserver,  p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionObserver));
-    opt.AddPolicy(AppRoles.ElectionVoter,     p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionVoter));
 });
 
 builder.Services.AddSignalR();

--- a/bvg-portal/src/app/core/constants/roles.ts
+++ b/bvg-portal/src/app/core/constants/roles.ts
@@ -1,0 +1,9 @@
+export const Roles = {
+  AttendanceRegistrar: 'AttendanceRegistrar',
+  VoteRegistrar: 'VoteRegistrar',
+  ElectionObserver: 'ElectionObserver'
+} as const;
+
+export type Role = (typeof Roles)[keyof typeof Roles];
+
+export const ALLOWED_ASSIGNMENT_ROLES: Role[] = Object.values(Roles);

--- a/bvg-portal/src/app/features/attendance/attendance-list.component.ts
+++ b/bvg-portal/src/app/features/attendance/attendance-list.component.ts
@@ -5,6 +5,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { Router } from '@angular/router';
 import { AuthService } from '../../core/auth.service';
+import { Roles } from '../../core/constants/roles';
 
 interface AssignedDto { id: string; name: string; scheduledAt: string; isClosed: boolean; }
 
@@ -44,7 +45,7 @@ export class AttendanceListComponent {
   items = signal<AssignedDto[]>([]);
   constructor(){ this.load(); }
   load(){
-    const role = 'AttendanceRegistrar';
+    const role = Roles.AttendanceRegistrar;
     this.http.get<AssignedDto[]>(`/api/elections/assigned?role=${role}`).subscribe({ next: d=> this.items.set(d||[]), error: _=> this.items.set([]) });
   }
   goReq(id: string){ this.router.navigate(['/attendance', id, 'requirements']); }

--- a/bvg-portal/src/app/features/dashboard/dashboard.component.ts
+++ b/bvg-portal/src/app/features/dashboard/dashboard.component.ts
@@ -4,6 +4,7 @@ import { NgIf, DatePipe, AsyncPipe } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import * as signalR from '@microsoft/signalr';
 import { AuthService } from '../../core/auth.service';
+import { Roles, ALLOWED_ASSIGNMENT_ROLES } from '../../core/constants/roles';
 
 @Component({
   selector: 'app-dashboard',
@@ -113,7 +114,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const isAdmin = this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin');
     let url = '/api/elections';
     if (!isAdmin) {
-      const role = this.auth.roles.find(r => ['AttendanceRegistrar','VoteRegistrar','ElectionVoter','ElectionObserver'].includes(r)) || 'AttendanceRegistrar';
+      const role = this.auth.roles.find(r => ALLOWED_ASSIGNMENT_ROLES.includes(r as any)) || Roles.AttendanceRegistrar;
       url = `/api/elections/assigned?role=${role}`;
     }
     this.http.get<any[]>(url).subscribe({

--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -22,6 +22,7 @@ import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { FilterPresentPipe } from './filter-present.pipe';
 import { AuthService } from '../../core/auth.service';
+import { Roles, ALLOWED_ASSIGNMENT_ROLES } from '../../core/constants/roles';
 
 @Component({
   selector: 'app-election-detail',
@@ -132,7 +133,7 @@ import { AuthService } from '../../core/auth.service';
           </mat-form-field>
           <mat-form-field appearance="outline">
             <mat-label>Rol</mat-label>
-            <input matInput formControlName="role" placeholder="ElectionObserver | AttendanceRegistrar | VoteRegistrar">
+            <input matInput formControlName="role" [placeholder]="assignmentRoles.join(' | ')">
           </mat-form-field>
           <button mat-raised-button color="primary" [disabled]="assignForm.invalid">Agregar</button>
         </form>
@@ -257,6 +258,7 @@ export class ElectionDetailComponent implements AfterViewInit {
   @ViewChild(MatSort) sort!: MatSort;
 
   assignForm = inject(FormBuilder).group({ userId: ['', Validators.required], role: ['', Validators.required] });
+  assignmentRoles = ALLOWED_ASSIGNMENT_ROLES;
 
   constructor(){
     this.id.set(this.route.snapshot.params['id']);
@@ -399,10 +401,10 @@ export class ElectionDetailComponent implements AfterViewInit {
   get canAttend(){
     if (this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin')) return true;
     const me = this.auth.payload?.sub;
-    return (this.assignments()||[]).some((a:any) => (a.userId ?? a.UserId) === me && (a.role ?? a.Role) === 'AttendanceRegistrar');
+    return (this.assignments()||[]).some((a:any) => (a.userId ?? a.UserId) === me && (a.role ?? a.Role) === Roles.AttendanceRegistrar);
   }
   get canRegister(){
-    return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin') || this.auth.hasRole('VoteRegistrar');
+    return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin') || this.auth.hasRole(Roles.VoteRegistrar);
   }
   get canClose(){ return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin'); }
 }

--- a/bvg-portal/src/app/features/elections/vote-list.component.ts
+++ b/bvg-portal/src/app/features/elections/vote-list.component.ts
@@ -4,6 +4,7 @@ import { NgIf, NgFor, DatePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { Router } from '@angular/router';
+import { Roles } from '../../core/constants/roles';
 
 interface AssignedDto { id: string; name: string; scheduledAt: string; isClosed: boolean; }
 
@@ -41,7 +42,7 @@ export class VoteListComponent {
   items = signal<AssignedDto[]>([]);
   constructor(){ this.load(); }
   load(){
-    this.http.get<AssignedDto[]>(`/api/elections/assigned?role=VoteRegistrar`).subscribe({ next: d=> this.items.set(d||[]), error: _=> this.items.set([]) });
+    this.http.get<AssignedDto[]>(`/api/elections/assigned?role=${Roles.VoteRegistrar}`).subscribe({ next: d=> this.items.set(d||[]), error: _=> this.items.set([]) });
   }
   start(id: string){
     this.http.post(`/api/elections/${id}/start`, {}).subscribe({


### PR DESCRIPTION
## Summary
- drop ElectionVoter from role constants
- remove backend policy and allowed-role references to ElectionVoter

## Testing
- `npm test` (fails: ng not found)
- `npm run build` (fails: ng not found)
- `dotnet test BvgAuthApi/BvgAuthApi.csproj` (fails: dotnet not found)


------
https://chatgpt.com/codex/tasks/task_b_68b71c173dc48322a2864ebf812ad283