### PR TITLE
refactor: adjust roles type

### DIFF
--- a/bvg-portal/src/app/core/constants/roles.ts
+++ b/bvg-portal/src/app/core/constants/roles.ts
@@ -1,7 +1,7 @@
 import rolesData from '../../../../../shared/roles.json';
 
-export const Roles = rolesData as const;
-export type Role = (typeof Roles)[keyof typeof Roles];
+export const Roles = rolesData;
+export type Role = keyof typeof Roles;
 export const ALLOWED_ASSIGNMENT_ROLES: Role[] = [
   Roles.AttendanceRegistrar,
   Roles.VoteRegistrar,


### PR DESCRIPTION
## Summary
- remove `as const` assertion from Roles export
- redefine Role type as `keyof typeof Roles`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b72eb1aec88322b679b39c0fd3835f