### PR TITLE
Use string literals for role assignments

### DIFF
--- a/bvg-portal/src/app/core/constants/roles.ts
+++ b/bvg-portal/src/app/core/constants/roles.ts
@@ -3,7 +3,7 @@ import rolesData from '../../../../../shared/roles.json';
 export const Roles = rolesData;
 export type Role = keyof typeof Roles;
 export const ALLOWED_ASSIGNMENT_ROLES: Role[] = [
-  Roles.AttendanceRegistrar,
-  Roles.VoteRegistrar,
-  Roles.ElectionObserver
+  'AttendanceRegistrar',
+  'VoteRegistrar',
+  'ElectionObserver'
 ];

--- a/bvg-portal/src/app/features/elections/election-wizard.component.ts
+++ b/bvg-portal/src/app/features/elections/election-wizard.component.ts
@@ -13,7 +13,7 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import * as XLSX from 'xlsx';
-import { Roles, ALLOWED_ASSIGNMENT_ROLES, Role } from '../../core/constants/roles';
+import { ALLOWED_ASSIGNMENT_ROLES, Role } from '../../core/constants/roles';
 import { firstValueFrom } from 'rxjs';
 
 interface User { id: string; userName: string; email: string; isActive: boolean; }
@@ -263,7 +263,7 @@ export class ElectionWizardComponent {
     if (!users.length) return;
     this.assignments.set([
       ...this.assignments(),
-      ...users.map(u=>({user:u, role: Roles.AttendanceRegistrar}))
+      ...users.map(u=>({user:u, role: 'AttendanceRegistrar'}))
     ]);
     this.selectedUsersAttendance.setValue([]);
   }
@@ -272,7 +272,7 @@ export class ElectionWizardComponent {
     if (!users.length) return;
     this.assignments.set([
       ...this.assignments(),
-      ...users.map(u=>({user:u, role: Roles.VoteRegistrar}))
+      ...users.map(u=>({user:u, role: 'VoteRegistrar'}))
     ]);
     this.selectedUsersVoting.setValue([]);
   }


### PR DESCRIPTION
## Summary
- use string literals in `ALLOWED_ASSIGNMENT_ROLES`
- adjust election wizard to assign roles by string literal

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7372cf8fc832294326f73be4394e3