### PR TITLE
Allow anonymous config fetch

### DIFF
--- a/BvgAuthApi/Endpoints/ConfigEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ConfigEndpoints.cs
@@ -30,7 +30,7 @@ namespace BvgAuthApi.Endpoints
                 );
                 var branding = new BrandingDto(cfg["Branding:LogoUrl"] ?? "");
                 return Results.Ok(new AppConfigDto(storage, smtp, azure, branding));
-            });
+            }).AllowAnonymous();
 
             g.MapPut("/", async ([FromBody] AppConfigDto dto, IWebHostEnvironment env) =>
             {


### PR DESCRIPTION
## Summary
- permit unauthenticated access to configuration endpoint so roles like Attendance Registrar can load the app configuration

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b73adc94a88322b3b2db72acfc03c1