### PR TITLE
Disable antiforgery for election creation

### DIFF
--- a/BvgAuthApi/Endpoints/ElectionEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ElectionEndpoints.cs
@@ -60,7 +60,7 @@ namespace BvgAuthApi.Endpoints
                 db.Elections.Add(e);
                 await db.SaveChangesAsync();
                 return Results.Created($"/api/elections/{e.Id}", new { e.Id });
-            }).RequireAuthorization(p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin));
+            }).RequireAuthorization(p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin)).DisableAntiforgery();
 
             g.MapGet("/", async (BvgDbContext db) =>
                 Results.Ok(await db.Elections.AsNoTracking()


### PR DESCRIPTION
## Summary
- disable antiforgery validation on election creation endpoint to prevent 400 errors when creating elections from the SPA

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b74645c8e883229ffa4afd28d3961c