### PR TITLE
Fix forbidden access to config endpoint

### DIFF
--- a/BvgAuthApi/Endpoints/ConfigEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ConfigEndpoints.cs
@@ -30,7 +30,7 @@ namespace BvgAuthApi.Endpoints
                 );
                 var branding = new BrandingDto(cfg["Branding:LogoUrl"] ?? "");
                 return Results.Ok(new AppConfigDto(storage, smtp, azure, branding));
-            }).AllowAnonymous();
+            }).AllowAnonymous().DisableAntiforgery();
 
             g.MapPut("/", async ([FromBody] AppConfigDto dto, IWebHostEnvironment env) =>
             {


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `/api/config/` without antiforgery

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found: dotnet)*
- `npm test` *(fails: sh: 1: ng: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@azure%2fmsal-browser)*

------
https://chatgpt.com/codex/tasks/task_b_68b74a27be1483228cc6c29fa3e124b0