### PR TITLE
Show vote registration to authorized registrars

### DIFF
--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -179,8 +179,8 @@ import { Roles, ALLOWED_ASSIGNMENT_ROLES } from '../../core/constants/roles';
         </div>
       </mat-card>
 
-      <!-- Solo mostrar registro de votos en modo edición -->
-      <mat-card *ngIf="canRegister && editMode()">
+      <!-- Se muestra el registro de votos si el usuario tiene permisos -->
+      <mat-card *ngIf="canRegister">
         <h3>Registrar voto</h3>
         <div class="vote-form">
           <mat-form-field appearance="outline">


### PR DESCRIPTION
## Summary
- Allow authorized users to view the vote registration section without needing edit mode

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@azure%2fmsal-browser)*

------
https://chatgpt.com/codex/tasks/task_b_68b76736053c8322b49015cfd7eba06b