### PR TITLE
Use per-election assignments for vote registration

### DIFF
--- a/BvgAuthApi/Program.cs
+++ b/BvgAuthApi/Program.cs
@@ -122,10 +122,8 @@ builder.Services.AddAuthorization(opt =>
 {
     opt.AddPolicy(AppRoles.GlobalAdmin, p => p.RequireRole(AppRoles.GlobalAdmin));
     opt.AddPolicy(AppRoles.VoteAdmin,   p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin));
-    opt.AddPolicy(AppRoles.ElectionRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionRegistrar));
-    opt.AddPolicy(AppRoles.AttendanceRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.AttendanceRegistrar));
-    opt.AddPolicy(AppRoles.VoteRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.VoteRegistrar));
-    opt.AddPolicy(AppRoles.ElectionObserver,  p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionObserver));
+    // Per-election roles (AttendanceRegistrar, VoteRegistrar, ElectionObserver) are handled via
+    // election-specific assignments rather than global authorization policies.
 });
 
 builder.Services.AddSignalR();

--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -409,7 +409,9 @@ export class ElectionDetailComponent implements AfterViewInit {
     return (this.assignments()||[]).some((a:any) => (a.userId ?? a.UserId) === me && (a.role ?? a.Role) === Roles.AttendanceRegistrar);
   }
   get canRegister(){
-    return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin') || this.auth.hasRole(Roles.VoteRegistrar);
+    if (this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin')) return true;
+    const me = this.auth.payload?.sub;
+    return (this.assignments()||[]).some((a:any) => (a.userId ?? a.UserId) === me && (a.role ?? a.Role) === Roles.VoteRegistrar);
   }
   get canClose(){ return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin'); }
 }


### PR DESCRIPTION
## Summary
- Remove global authorization policies for vote-related sub-roles
- Allow vote registrars via election assignments instead of global role

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b76e90e7a4832293e52046f62c9401