### PR TITLE
Use per-election assignments for vote registration

### DIFF
--- a/BvgAuthApi/Endpoints/ElectionEndpoints.cs
+++ b/BvgAuthApi/Endpoints/ElectionEndpoints.cs
@@ -248,17 +248,18 @@ namespace BvgAuthApi.Endpoints
             }).RequireAuthorization();
 
             // Assigned elections for current user and role
-            g.MapGet("/assigned", async (string? role, BvgDbContext db, ClaimsPrincipal user) =>
+            g.MapGet("/assigned", async (string role, BvgDbContext db, ClaimsPrincipal user) =>
             {
                 var userId = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value ?? user.FindFirst("sub")?.Value ?? "";
-                var r = string.IsNullOrWhiteSpace(role) ? AppRoles.ElectionRegistrar : role!;
-                r = r.Trim();
-                var rLower = r.ToLower();
+                var rLower = role.Trim().ToLower();
                 var ids = await db.ElectionUserAssignments
                     .Where(a => a.UserId == userId && a.Role.ToLower() == rLower)
                     .Select(a => a.ElectionId)
                     .ToListAsync();
-                var items = await db.Elections.Where(e => ids.Contains(e.Id)).Select(e => new { e.Id, e.Name, e.ScheduledAt, e.IsClosed }).ToListAsync();
+                var items = await db.Elections
+                    .Where(e => ids.Contains(e.Id))
+                    .Select(e => new { e.Id, e.Name, e.ScheduledAt, e.IsClosed })
+                    .ToListAsync();
                 return Results.Ok(items);
             }).RequireAuthorization();
 

--- a/BvgAuthApi/Models/AppModels.cs
+++ b/BvgAuthApi/Models/AppModels.cs
@@ -15,7 +15,6 @@
         public static string GlobalAdmin => _roles[nameof(GlobalAdmin)];
         public static string VoteAdmin   => _roles[nameof(VoteAdmin)];
         public static string Functional  => _roles[nameof(Functional)];
-        public static string ElectionRegistrar => _roles[nameof(ElectionRegistrar)];
         public static string AttendanceRegistrar => _roles[nameof(AttendanceRegistrar)];
         public static string VoteRegistrar => _roles[nameof(VoteRegistrar)];
         public static string ElectionObserver  => _roles[nameof(ElectionObserver)];

--- a/BvgAuthApi/Program.cs
+++ b/BvgAuthApi/Program.cs
@@ -122,10 +122,8 @@ builder.Services.AddAuthorization(opt =>
 {
     opt.AddPolicy(AppRoles.GlobalAdmin, p => p.RequireRole(AppRoles.GlobalAdmin));
     opt.AddPolicy(AppRoles.VoteAdmin,   p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin));
-    opt.AddPolicy(AppRoles.ElectionRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionRegistrar));
-    opt.AddPolicy(AppRoles.AttendanceRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.AttendanceRegistrar));
-    opt.AddPolicy(AppRoles.VoteRegistrar, p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.VoteRegistrar));
-    opt.AddPolicy(AppRoles.ElectionObserver,  p => p.RequireRole(AppRoles.GlobalAdmin, AppRoles.VoteAdmin, AppRoles.ElectionObserver));
+    // Per-election roles (AttendanceRegistrar, VoteRegistrar, ElectionObserver) are handled via
+    // election-specific assignments rather than global authorization policies.
 });
 
 builder.Services.AddSignalR();

--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -409,7 +409,9 @@ export class ElectionDetailComponent implements AfterViewInit {
     return (this.assignments()||[]).some((a:any) => (a.userId ?? a.UserId) === me && (a.role ?? a.Role) === Roles.AttendanceRegistrar);
   }
   get canRegister(){
-    return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin') || this.auth.hasRole(Roles.VoteRegistrar);
+    if (this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin')) return true;
+    const me = this.auth.payload?.sub;
+    return (this.assignments()||[]).some((a:any) => (a.userId ?? a.UserId) === me && (a.role ?? a.Role) === Roles.VoteRegistrar);
   }
   get canClose(){ return this.auth.hasRole('GlobalAdmin') || this.auth.hasRole('VoteAdmin'); }
 }

--- a/shared/roles.json
+++ b/shared/roles.json
@@ -2,7 +2,6 @@
   "GlobalAdmin": "GlobalAdmin",
   "VoteAdmin": "VoteAdmin",
   "Functional": "Functional",
-  "ElectionRegistrar": "ElectionRegistrar",
   "AttendanceRegistrar": "AttendanceRegistrar",
   "VoteRegistrar": "VoteRegistrar",
   "ElectionObserver": "ElectionObserver"


### PR DESCRIPTION
## Summary
- Remove global authorization policies for vote-related sub-roles
- Allow vote registrars via election assignments instead of global role
- Drop unused ElectionRegistrar role and require explicit role when listing assigned elections

## Testing
- `dotnet build BvgAuthApi/BvgAuthApi.csproj` *(fails: command not found)*
- `npm ci` *(fails: 403 Forbidden fetching @azure/msal-browser)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b76e90e7a4832293e52046f62c9401