### PR TITLE
Refactor vote registration with stepper

### DIFF
--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -8,7 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTableModule } from '@angular/material/table';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators, FormControl } from '@angular/forms';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { LiveService } from '../../core/live.service';
@@ -16,18 +16,22 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatStepperModule, MatStepper } from '@angular/material/stepper';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { FilterPresentPipe } from './filter-present.pipe';
 import { AuthService } from '../../core/auth.service';
+import { VoteConfirmDialogComponent } from './vote-confirm-dialog.component';
 import { Roles, ALLOWED_ASSIGNMENT_ROLES } from '../../core/constants/roles';
 
 @Component({
   selector: 'app-election-detail',
   standalone: true,
-  imports: [NgFor, NgIf, DecimalPipe, DatePipe, MatCardModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatTableModule, MatSnackBarModule, ReactiveFormsModule, MatSelectModule, MatPaginatorModule, MatSortModule, MatProgressBarModule, FilterPresentPipe, MatDatepickerModule, MatNativeDateModule],
+  imports: [NgFor, NgIf, DecimalPipe, DatePipe, MatCardModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatTableModule, MatSnackBarModule, ReactiveFormsModule, MatSelectModule, MatPaginatorModule, MatSortModule, MatProgressBarModule, FilterPresentPipe, MatDatepickerModule, MatNativeDateModule, MatStepperModule, MatAutocompleteModule, MatDialogModule],
   template: `
   <div class="page">
     <h2>Elección {{id()}}</h2>
@@ -182,27 +186,56 @@ import { Roles, ALLOWED_ASSIGNMENT_ROLES } from '../../core/constants/roles';
       <!-- Se muestra el registro de votos si el usuario tiene permisos -->
       <mat-card *ngIf="canRegister">
         <h3>Registrar voto</h3>
-        <div class="vote-form">
-          <mat-form-field appearance="outline">
-            <mat-label>Accionista presente</mat-label>
-            <mat-select [(value)]="votePadronId">
-              <mat-option *ngFor="let p of padronDS.data | filterPresent" [value]="p.id">{{p.shareholderName}} ({{p.shares}})</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-form-field appearance="outline">
-            <mat-label>Pregunta</mat-label>
-            <mat-select [(value)]="voteQuestionId" (selectionChange)="voteOptionId=null">
-              <mat-option *ngFor="let q of results()" [value]="q.questionId">{{q.text}}</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-form-field appearance="outline">
-            <mat-label>Opción</mat-label>
-            <mat-select [(value)]="voteOptionId">
-              <mat-option *ngFor="let o of getOptionsForSelectedQuestion()" [value]="o.optionId">{{o.text}}</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <button mat-raised-button color="primary" (click)="registerVote()" [disabled]="!votePadronId || !voteQuestionId || !voteOptionId">Registrar</button>
-        </div>
+        <mat-stepper orientation="horizontal" linear #voteStepper>
+          <mat-step [stepControl]="voteStep1">
+            <form [formGroup]="voteStep1">
+              <ng-template matStepLabel>Accionista</ng-template>
+              <mat-form-field appearance="outline" class="full">
+                <mat-label>Accionista presente</mat-label>
+                <input type="text" matInput formControlName="padron" [matAutocomplete]="padronAuto">
+                <mat-autocomplete #padronAuto="matAutocomplete" [displayWith]="displayPadron">
+                  <mat-option *ngFor="let p of filteredPadron()" [value]="p">{{p.shareholderName}} ({{p.shares}})</mat-option>
+                </mat-autocomplete>
+                <mat-error *ngIf="padronCtrl.invalid && padronCtrl.touched">Seleccione un accionista</mat-error>
+              </mat-form-field>
+              <div>
+                <button mat-button matStepperNext [disabled]="voteStep1.invalid">Siguiente</button>
+              </div>
+            </form>
+          </mat-step>
+          <mat-step [stepControl]="voteStep2">
+            <form [formGroup]="voteStep2">
+              <ng-template matStepLabel>Pregunta</ng-template>
+              <mat-form-field appearance="outline" class="full">
+                <mat-label>Pregunta</mat-label>
+                <mat-select formControlName="questionId" (selectionChange)="optionCtrl.reset()">
+                  <mat-option *ngFor="let q of results()" [value]="q.questionId">{{q.text}}</mat-option>
+                </mat-select>
+                <mat-error *ngIf="questionCtrl.invalid && questionCtrl.touched">Seleccione una pregunta</mat-error>
+              </mat-form-field>
+              <div>
+                <button mat-button matStepperPrevious>Anterior</button>
+                <button mat-button matStepperNext [disabled]="voteStep2.invalid">Siguiente</button>
+              </div>
+            </form>
+          </mat-step>
+          <mat-step [stepControl]="voteStep3">
+            <form [formGroup]="voteStep3">
+              <ng-template matStepLabel>Opción</ng-template>
+              <mat-form-field appearance="outline" class="full">
+                <mat-label>Opción</mat-label>
+                <mat-select formControlName="optionId">
+                  <mat-option *ngFor="let o of getOptionsForSelectedQuestion()" [value]="o.optionId">{{o.text}}</mat-option>
+                </mat-select>
+                <mat-error *ngIf="optionCtrl.invalid && optionCtrl.touched">Seleccione una opción</mat-error>
+              </mat-form-field>
+              <div>
+                <button mat-button matStepperPrevious>Anterior</button>
+                <button mat-raised-button color="primary" (click)="confirmVote(voteStepper)" [disabled]="voteStep3.invalid">Registrar</button>
+              </div>
+            </form>
+          </mat-step>
+        </mat-stepper>
         <div class="mt8" *ngIf="canClose">
           <button mat-stroked-button color="warn" (click)="closeElection()">Cerrar elección</button>
         </div>
@@ -218,6 +251,7 @@ import { Roles, ALLOWED_ASSIGNMENT_ROLES } from '../../core/constants/roles';
      .assign-form{display:flex; gap:8px; align-items:center; flex-wrap:wrap}
      .q{margin-bottom:12px}
      .vote-form{display:flex; gap:8px; flex-wrap:wrap; align-items:center}
+     .full{width:100%}
      .mt8{margin-top:8px}
      table.compact th, table.compact td{ font-size:13px }
      .edit-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap:12px; align-items:end }
@@ -231,6 +265,7 @@ export class ElectionDetailComponent implements AfterViewInit {
   private snack = inject(MatSnackBar);
   private live = inject(LiveService);
   private auth = inject(AuthService);
+  private dialog = inject(MatDialog);
 
   id = signal<string>('');
   editMode = signal(false);
@@ -250,9 +285,13 @@ export class ElectionDetailComponent implements AfterViewInit {
   quorum = signal<{total:number,present:number,quorum:number}|null>(null);
   electionInfo = signal<any|null>(null);
 
-  votePadronId: string | null = null;
-  voteQuestionId: string | null = null;
-  voteOptionId: string | null = null;
+  padronCtrl = new FormControl('', Validators.required);
+  questionCtrl = new FormControl('', Validators.required);
+  optionCtrl = new FormControl('', Validators.required);
+  voteStep1 = inject(FormBuilder).group({ padron: this.padronCtrl });
+  voteStep2 = inject(FormBuilder).group({ questionId: this.questionCtrl });
+  voteStep3 = inject(FormBuilder).group({ optionId: this.optionCtrl });
+  filteredPadron = signal<any[]>([]);
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
@@ -277,6 +316,11 @@ export class ElectionDetailComponent implements AfterViewInit {
       }
     });
     if (this.editMode()) this.prefillEdit();
+    this.padronCtrl.valueChanges.subscribe(val => {
+      const term = (typeof val === 'string' ? val : val?.shareholderName || '').toLowerCase();
+      const base = this.padronDS.data.filter((p:any) => p.attendance === 'Presencial' || p.attendance === 'Virtual');
+      this.filteredPadron.set(base.filter((p:any) => (p.shareholderName || '').toLowerCase().includes(term)));
+    });
   }
   ngAfterViewInit(){
     if (this.paginator) this.padronDS.paginator = this.paginator;
@@ -329,7 +373,17 @@ export class ElectionDetailComponent implements AfterViewInit {
     });
   }
 
-  loadPadron(){ this.http.get<any[]>(`/api/elections/${this.id()}/padron`).subscribe({ next: d=> { this.padronDS.data = d; this.ngAfterViewInit(); }, error: _=> { this.padronDS.data = []; } }); }
+  loadPadron(){
+    this.http.get<any[]>(`/api/elections/${this.id()}/padron`).subscribe({
+      next: d=> {
+        this.padronDS.data = d;
+        this.ngAfterViewInit();
+        this.filteredPadron.set(this.padronDS.data.filter(p => p.attendance === 'Presencial' || p.attendance === 'Virtual'));
+        this.padronCtrl.setValue(this.padronCtrl.value || '');
+      },
+      error: _=> { this.padronDS.data = []; this.filteredPadron.set([]); }
+    });
+  }
   loadQuorum(){
     this.http.get<any>(`/api/elections/${this.id()}/quorum`).subscribe({
       next: d=> {
@@ -377,12 +431,12 @@ export class ElectionDetailComponent implements AfterViewInit {
   cancelEdit(){ this.router.navigate(['/elections', this.id()]); this.editMode.set(false); }
 
   getOptionsForSelectedQuestion(){
-    const q = this.results().find((x:any)=> (x.questionId ?? x.QuestionId) === this.voteQuestionId);
+    const qId = this.questionCtrl.value;
+    const q = this.results().find((x:any)=> (x.questionId ?? x.QuestionId) === qId);
     return q ? (q.options ?? q.Options) : [];
   }
-  registerVote(){
-    if (!this.votePadronId || !this.voteQuestionId || !this.voteOptionId) return;
-    const dto = { padronId: this.votePadronId, questionId: this.voteQuestionId, optionId: this.voteOptionId } as any;
+  registerVote(padronId: string, questionId: string, optionId: string){
+    const dto = { padronId, questionId, optionId } as any;
     this.http.post(`/api/elections/${this.id()}/votes`, dto).subscribe({
       next: _=> { this.snack.open('Voto registrado','OK',{duration:1500}); this.loadResults(); this.live.onVoteRegistered(()=>{}); },
       error: err => {
@@ -392,6 +446,25 @@ export class ElectionDetailComponent implements AfterViewInit {
       }
     });
   }
+  confirmVote(stepper: MatStepper){
+    const padron = this.padronCtrl.value;
+    const questionId = this.questionCtrl.value;
+    const optionId = this.optionCtrl.value;
+    if (!padron || !questionId || !optionId) return;
+    const question = this.results().find((q:any)=> (q.questionId ?? q.QuestionId) === questionId);
+    const option = this.getOptionsForSelectedQuestion().find((o:any)=> (o.optionId ?? o.OptionId) === optionId);
+    const ref = this.dialog.open(VoteConfirmDialogComponent, { data: { shareholder: padron, question, option } });
+    ref.afterClosed().subscribe(ok => {
+      if (ok){
+        this.registerVote(padron.id, questionId, optionId);
+        stepper.reset();
+        this.padronCtrl.reset('');
+        this.questionCtrl.reset('');
+        this.optionCtrl.reset('');
+      }
+    });
+  }
+  displayPadron(p:any){ return p?.shareholderName || ''; }
   closeElection(){
     this.http.post(`/api/elections/${this.id()}/close`, {}).subscribe({
       next: _=> { this.snack.open('Elección cerrada','OK',{duration:2000}); this.loadResults(); },

--- a/bvg-portal/src/app/features/elections/vote-confirm-dialog.component.ts
+++ b/bvg-portal/src/app/features/elections/vote-confirm-dialog.component.ts
@@ -1,0 +1,26 @@
+import { Component, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-vote-confirm-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule, NgIf],
+  template: `
+    <h2 mat-dialog-title>Confirmar voto</h2>
+    <div mat-dialog-content>
+      <p><b>Accionista:</b> {{data.shareholder.shareholderName}}</p>
+      <p><b>Pregunta:</b> {{data.question.text}}</p>
+      <p><b>Opción:</b> {{data.option.text}}</p>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button mat-dialog-close>Cancelar</button>
+      <button mat-raised-button color="primary" [mat-dialog-close]="true">Confirmar</button>
+    </div>
+  `
+})
+export class VoteConfirmDialogComponent {
+  data = inject(MAT_DIALOG_DATA);
+}
+


### PR DESCRIPTION
## Summary
- refactor vote registration into a stepper with searchable shareholder field
- add confirmation dialog before saving vote

## Testing
- `npm test` (fails: ng: not found)
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/@azure%2fmsal-browser)


------
https://chatgpt.com/codex/tasks/task_b_68b8480ab8c48322b855a357fc65cea0