### PR TITLE
fix: type safety for vote registration

### DIFF
--- a/bvg-portal/src/app/features/elections/vote-confirm-dialog.component.ts
+++ b/bvg-portal/src/app/features/elections/vote-confirm-dialog.component.ts
@@ -1,0 +1,26 @@
+import { Component, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-vote-confirm-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule, NgIf],
+  template: `
+    <h2 mat-dialog-title>Confirmar voto</h2>
+    <div mat-dialog-content>
+      <p><b>Accionista:</b> {{data.shareholder.shareholderName}}</p>
+      <p><b>Pregunta:</b> {{data.question.text}}</p>
+      <p><b>Opción:</b> {{data.option.text}}</p>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button mat-dialog-close>Cancelar</button>
+      <button mat-raised-button color="primary" [mat-dialog-close]="true">Confirmar</button>
+    </div>
+  `
+})
+export class VoteConfirmDialogComponent {
+  data = inject(MAT_DIALOG_DATA);
+}
+


### PR DESCRIPTION
## Summary
- type padron form control and data source using `PadronRow`
- validate shareholder selection before registering vote

## Testing
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/@azure%2fmsal-browser)
- `npm test` (fails: ng: not found)


------
https://chatgpt.com/codex/tasks/task_b_68b8480ab8c48322b855a357fc65cea0