### PR TITLE
fix: close if block in election component

### DIFF
--- a/bvg-portal/src/app/features/elections/election-detail.component.ts
+++ b/bvg-portal/src/app/features/elections/election-detail.component.ts
@@ -455,6 +455,7 @@ export class ElectionDetailComponent implements AfterViewInit {
     if (typeof padron !== 'object' || !padron.id) {
       this.snack.open('Seleccione un accionista válido','OK',{duration:2000});
       return;
+    }
     const question = this.results().find((q:any)=> (q.questionId ?? q.QuestionId) === questionId);
     const option = this.getOptionsForSelectedQuestion().find((o:any)=> (o.optionId ?? o.OptionId) === optionId);
     const ref = this.dialog.open(VoteConfirmDialogComponent, { data: { shareholder: padron, question, option } });


### PR DESCRIPTION
## Summary
- restore missing closing brace in election detail's confirmVote method

## Testing
- `npm run build` *(fails: ng: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@azure%2fmsal-browser)*

------
https://chatgpt.com/codex/tasks/task_b_68b85001891c832289286d00d28f7600